### PR TITLE
Unhardcoded app launcher icon filetype

### DIFF
--- a/data/anbox.desktop
+++ b/data/anbox.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Anbox
 Exec=anbox run --rootfs=android-rootfs
-Icon=anbox.png
+Icon=anbox
 Terminal=false
 Type=Application
 X-Ubuntu-Touch=true


### PR DESCRIPTION
Since you're going to install the icon to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) (I take it that way, otherwise you'd have to specify the full path) you don't need to specify the icon file extension in the `.desktop` launcher. It will be found anyway.

This facilitates the use of non-PNG (e.g. SVG) app icon themes.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).
