### PR TITLE
README.md: Fix snapd install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ installer will perform all necessary steps. You can install it on a system
 providing support for snaps by running
 
 ```
-$ snap install --classic anbox-installer
+$ snap install anbox-installer --classic
 ```
 
 Alternatively you can fetch the installer script via


### PR DESCRIPTION
On Xubuntu 16.10, following the README.md instructions gives this message:
 > error: unknown flag `clasic'

**Note:**  yes, the message has this weird inconsistency of having a backtick at the start and a single quote at the end.

However, if the argument order is changed, it works just fine again.

My `snap --version` output, in case it might be helpful:
```text
feik@feik-Q500A:~$ snap --version
snap    2.23.6
snapd   2.23.6
series  16
ubuntu  16.10
kernel  4.8.0-46-generic
```
