### PR TITLE
docs: build-android.md: Add missing step to initialise the build env

### DIFF
--- a/docs/build-android.md
+++ b/docs/build-android.md
@@ -33,8 +33,15 @@ This will take quite some time depending on the speed of your internet connectio
 
 ## Build Android
 
-When all sources are successfully downloaded you can start building Android
-itself. Initialize the build by
+When all sources are successfully downloaded you can start building Android itself.
+
+Firstly initialize the environment with the ```envsetup.sh``` script.
+
+```
+$ . build/envsetup.sh
+```
+
+Then initialize the build using ```lunch```.
 
 ```
 $ lunch anbox_desktop_x86_64-userdebug

--- a/src/anbox/rpc/connection_creator.cpp
+++ b/src/anbox/rpc/connection_creator.cpp
@@ -43,8 +43,7 @@ void ConnectionCreator::create_connection_for(
     socket->close();
     WARNING(
         "A second client tried to connect. Denied request as we already have "
-        "one"
-        "and only allow a single client");
+        "one and only allow a single client");
     return;
   }
 


### PR DESCRIPTION
Setting up the build environment is a required step.

Without it, the subsequent step `lunch` will not be available.

Signed-off-by: Lee Jones <lee.jones@linaro.org>

Fixes https://github.com/anbox/anbox/issues/222