### PR TITLE
Make sure helper libraries get built as static libs

### DIFF
--- a/external/android-emugl/host/libs/GLESv1_dec/CMakeLists.txt
+++ b/external/android-emugl/host/libs/GLESv1_dec/CMakeLists.txt
@@ -20,5 +20,5 @@ if ("${cmake_build_type_lower}" STREQUAL "trace")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENGL_DEBUG}")
 endif()
 
-add_library(GLESv1_dec ${SOURCES} ${GENERATED_SOURCES})
+add_library(GLESv1_dec STATIC ${SOURCES} ${GENERATED_SOURCES})
 target_link_libraries(GLESv1_dec OpenglCodecCommon)

--- a/external/android-emugl/host/libs/GLESv2_dec/CMakeLists.txt
+++ b/external/android-emugl/host/libs/GLESv2_dec/CMakeLists.txt
@@ -20,5 +20,5 @@ if ("${cmake_build_type_lower}" STREQUAL "trace")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENGL_DEBUG}")
 endif()
 
-add_library(GLESv2_dec ${SOURCES} ${GENERATED_SOURCES})
+add_library(GLESv2_dec STATIC ${SOURCES} ${GENERATED_SOURCES})
 target_link_libraries(GLESv2_dec OpenglCodecCommon)

--- a/external/android-emugl/host/libs/Translator/GLcommon/CMakeLists.txt
+++ b/external/android-emugl/host/libs/Translator/GLcommon/CMakeLists.txt
@@ -12,6 +12,6 @@ set(SOURCES
     objectNameManager.cpp
     FramebufferData.cpp)
 
-add_library(GLcommon ${SOURCES})
+add_library(GLcommon STATIC ${SOURCES})
 target_link_libraries(GLcommon
     emugl_common)

--- a/external/android-emugl/host/libs/libOpenGLESDispatch/CMakeLists.txt
+++ b/external/android-emugl/host/libs/libOpenGLESDispatch/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOURCES
     GLESv2Dispatch.cpp
     GLESv1Dispatch.cpp)
 
-add_library(OpenGLESDispatch ${SOURCES} ${GENERATED_SOURCES})
+add_library(OpenGLESDispatch STATIC ${SOURCES} ${GENERATED_SOURCES})
 target_link_libraries(OpenGLESDispatch
     emugl_common
     GLESv2_dec

--- a/external/android-emugl/host/libs/renderControl_dec/CMakeLists.txt
+++ b/external/android-emugl/host/libs/renderControl_dec/CMakeLists.txt
@@ -16,5 +16,5 @@ if ("${cmake_build_type_lower}" STREQUAL "trace")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENGL_DEBUG}")
 endif()
 
-add_library(renderControl_dec ${GENERATED_SOURCES})
+add_library(renderControl_dec STATIC ${GENERATED_SOURCES})
 target_link_libraries(renderControl_dec OpenglCodecCommon)

--- a/external/android-emugl/shared/OpenglCodecCommon/CMakeLists.txt
+++ b/external/android-emugl/shared/OpenglCodecCommon/CMakeLists.txt
@@ -12,4 +12,4 @@ set(SOURCES
     Makefile
     ProtocolUtils.h)
 
-add_library(OpenglCodecCommon ${SOURCES})
+add_library(OpenglCodecCommon STATIC ${SOURCES})

--- a/external/android-emugl/shared/emugl/common/CMakeLists.txt
+++ b/external/android-emugl/shared/emugl/common/CMakeLists.txt
@@ -28,6 +28,6 @@ set(COMMON_SOURCES
     thread_unittest.cpp
     unique_integer_map.h)
 
-add_library(emugl_common ${COMMON_SOURCES})
+add_library(emugl_common STATIC ${COMMON_SOURCES})
 target_link_libraries(emugl_common
     dl pthread)

--- a/external/process-cpp-minimal/src/CMakeLists.txt
+++ b/external/process-cpp-minimal/src/CMakeLists.txt
@@ -15,6 +15,8 @@
 # Authored by: Thomas Voss <thomas.voss@canonical.com>
 add_library(
   process-cpp
+
+  STATIC
   
   core/posix/backtrace.h
   core/posix/backtrace.cpp

--- a/external/xdg/CMakeLists.txt
+++ b/external/xdg/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(
     ${Boost_INCLUDE_DIRS}
 )
 
-add_library(xdg xdg.cpp)
+add_library(xdg STATIC xdg.cpp)
 set_property(TARGET xdg PROPERTY CXX_STANDARD 11)
 target_link_libraries(xdg ${Boost_LIBRARIES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ protobuf_generate_cpp(
 
 
 add_library(anbox-protobuf
+    STATIC
     ${GENERATED_PROTOBUF_BRIDGE_SRCS}
     ${GENERATED_PROTOBUF_BRIDGE_HDRS}
     ${GENERATED_PROTOBUF_RPC_SRCS}
@@ -207,7 +208,7 @@ set(SOURCES
     anbox/optional.h
     anbox/defer_action.h)
 
-add_library(anbox-core ${SOURCES})
+add_library(anbox-core STATIC ${SOURCES})
 target_link_libraries(anbox-core
   ${Boost_LDFLAGS}
   ${Boost_LIBRARIES}


### PR DESCRIPTION
Make sure helper libraries get built as static libs regardless
of the cmake version being used.

This fixes issue #217

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>