### PR TITLE
cmds: session_manager: Provide an option to use any container

### DIFF
--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -109,6 +109,9 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
   flag(cli::make_flag(cli::Name{"standalone"},
                       cli::Description{"Prevents the Container Manager from starting the default container (Experimental)"},
                       standalone_));
+  flag(cli::make_flag(cli::Name{"experimental"},
+                      cli::Description{"Allows users to use experimental features"},
+                      experimental_));
 
   action([this](const cli::Command::Context &) {
     auto trap = core::posix::trap_signals_for_process(
@@ -117,6 +120,11 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
       INFO("Signal %i received. Good night.", static_cast<int>(signal));
       trap->stop();
     });
+
+    if (standalone_ && !experimental_) {
+      ERROR("Experimental features selected, but --experimental flag not set");
+      return EXIT_FAILURE;
+    }
 
     if (!fs::exists("/dev/binder") || !fs::exists("/dev/ashmem")) {
       ERROR("Failed to start as either binder or ashmem kernel drivers are not loaded");

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -146,9 +146,9 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
     auto rt = Runtime::create();
     auto dispatcher = anbox::common::create_dispatcher_for_runtime(rt);
 
-    container::Client container(rt);
     if (!standalone_) {
-      container.register_terminate_handler([&]() {
+      container_ = std::make_shared<container::Client>(rt);
+      container_->register_terminate_handler([&]() {
 	  WARNING("Lost connection to container manager, terminating.");
 	  trap->stop();
 	});
@@ -237,7 +237,7 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
         {"/dev/fuse", "/dev/fuse"},
       };
 
-      dispatcher->dispatch([&]() { container.start(container_configuration); });
+      dispatcher->dispatch([&]() { container_->start(container_configuration); });
     }
 
     auto bus = bus_factory_();
@@ -251,7 +251,7 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
     if (!standalone_) {
       // Stop the container which should close all open connections we have on
       // our side and should terminate all services.
-      container.stop();
+      container_->stop();
     }
 
     rt->stop();

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -46,6 +46,7 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   bool single_window_ = false;
   graphics::Rect window_size_;
   bool standalone_ = false;
+  bool experimental_ = false;
 };
 }  // namespace cmds
 }  // namespace anbox

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -45,6 +45,7 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   graphics::GLRendererServer::Config::Driver gles_driver_;
   bool single_window_ = false;
   graphics::Rect window_size_;
+  bool standalone_ = false;
 };
 }  // namespace cmds
 }  // namespace anbox

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -30,6 +30,9 @@
 #include "anbox/graphics/rect.h"
 
 namespace anbox {
+namespace container {
+class Client;
+}  // namespace container
 namespace cmds {
 class SessionManager : public cli::CommandWithFlagsAndAction {
  public:
@@ -40,6 +43,7 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   SessionManager(const BusFactory& bus_factory = session_bus_factory());
 
  private:
+  std::shared_ptr<container::Client> container_;
   BusFactory bus_factory_;
   std::string desktop_file_hint_;
   graphics::GLRendererServer::Config::Driver gles_driver_;


### PR DESCRIPTION
Normally Anbox will use the default container provided by the
Anbox Container Manager, but some users may wish to run their
own container.  Here we're adding a --use-own-container flag
which tells the session-manager not to interact (configure/
start) the Container Manager.  This allows the user to utilise
any other bespoke container of their choosing.  For instance,
this new feature was testing using Docker container running
the android.img provided by Anbox.

Signed-off-by: Lee Jones <lee.jones@linaro.org>