### PR TITLE
Print warning if user starts container manager manually

### DIFF
--- a/scripts/container-manager.sh
+++ b/scripts/container-manager.sh
@@ -37,7 +37,8 @@ start() {
 
 	exec $AA_EXEC $SNAP/bin/anbox-wrapper.sh container-manager \
 		--data-path=$DATA_PATH \
-		--android-image=$ANDROID_IMG
+		--android-image=$ANDROID_IMG \
+		--daemon
 }
 
 stop() {

--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -62,7 +62,7 @@ anbox::cmds::ContainerManager::ContainerManager()
         WARNING("");
       }
 
-      if (getuid() != 0) {
+      if (geteuid() != 0) {
         ERROR("You are not running the container-manager as root. Generally you don't");
         ERROR("want to run the container-manager manually unless you're a developer");
         ERROR("as it is started by the init system of your operating system.");

--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -57,7 +57,7 @@ anbox::cmds::ContainerManager::ContainerManager()
       if (!daemon_) {
         WARNING("You are running the container manager manually which is most likely not");
         WARNING("what you want. The container manager is normally started by systemd or");
-        WARNING("or another init system. If you still want to run the container-manager");
+        WARNING("another init system. If you still want to run the container-manager");
         WARNING("you can get rid of this warning by starting with the --daemon option.");
         WARNING("");
       }

--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -48,11 +48,22 @@ anbox::cmds::ContainerManager::ContainerManager()
   flag(cli::make_flag(cli::Name{"privileged"},
                       cli::Description{"Run Android container in privileged mode"},
                       privileged_));
+  flag(cli::make_flag(cli::Name{"daemon"},
+                      cli::Description{"Mark service as being started as systemd daemon"},
+                      daemon_));
 
   action([&](const cli::Command::Context&) {
     try {
+      if (!daemon_) {
+        WARNING("You are running the container manager manually which is most likely not");
+        WARNING("what you want. The container manager is normally started by systemd or");
+        WARNING("or another init system. If you still want to run the container-manager");
+        WARNING("you can get rid of this warning by starting with the --daemon option.");
+        WARNING("");
+      }
+
       if (getuid() != 0) {
-        ERROR("You're not running the container-manager as root. Generally you don't");
+        ERROR("You are not running the container-manager as root. Generally you don't");
         ERROR("want to run the container-manager manually unless you're a developer");
         ERROR("as it is started by the init system of your operating system.");
         return EXIT_FAILURE;

--- a/src/anbox/cmds/container_manager.h
+++ b/src/anbox/cmds/container_manager.h
@@ -42,6 +42,7 @@ class ContainerManager : public cli::CommandWithFlagsAndAction {
   std::shared_ptr<common::LoopDevice> android_img_loop_dev_;
   std::vector<std::shared_ptr<common::MountEntry>> mounts_;
   bool privileged_ = false;
+  bool daemon_ = false;
 };
 }  // namespace cmds
 }  // namespace anbox


### PR DESCRIPTION
This will tell users what they are doing wrong when they are running the container manager manually like a lot of people do as our bug reports show.