### PR TITLE
Update build-android.md

### DIFF
--- a/docs/build-android.md
+++ b/docs/build-android.md
@@ -50,7 +50,7 @@ $ lunch anbox_desktop_x86_64-userdebug
 The complete list of supported build targets:
 
  * anbox_desktop_x86_64-userdebug
- * anbox_desktop_armv7a_arm-userdebug
+ * anbox_desktop_armv7a_neon-userdebug
  * anbox_desktop_arm64-userdebug
 
 Now build everything with


### PR DESCRIPTION
"anbox_desktop_armv7a_arm" is already renamed to "anbox_desktop_armv7a_neon".