### PR TITLE
Fix build with clang

### DIFF
--- a/external/xdg/xdg.cpp
+++ b/external/xdg/xdg.cpp
@@ -57,7 +57,6 @@ constexpr const char* xdg_data_dirs{"XDG_DATA_DIRS"};
 constexpr const char* xdg_config_home{"XDG_CONFIG_HOME"};
 constexpr const char* xdg_config_dirs{"XDG_CONFIG_DIRS"};
 constexpr const char* xdg_cache_home{"XDG_CACHE_HOME"};
-constexpr const char* xdg_runtime_dir{"XDG_RUNTIME_DIR"};
 }
 
 namespace impl

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -27,12 +27,17 @@
 #include "anbox/bridge/android_api_stub.h"
 #include "anbox/bridge/platform_api_skeleton.h"
 #include "anbox/bridge/platform_message_processor.h"
+#include "anbox/graphics/gl_renderer_server.h"
+
+namespace {
+std::istream& operator>>(std::istream& in, anbox::graphics::GLRendererServer::Config::Driver& driver);
+}
+
 #include "anbox/cmds/session_manager.h"
 #include "anbox/common/dispatcher.h"
 #include "anbox/config.h"
 #include "anbox/container/client.h"
 #include "anbox/dbus/skeleton/service.h"
-#include "anbox/graphics/gl_renderer_server.h"
 #include "anbox/input/manager.h"
 #include "anbox/logger.h"
 #include "anbox/network/published_socket_connector.h"

--- a/src/anbox/graphics/emugl/ColorBuffer.cpp
+++ b/src/anbox/graphics/emugl/ColorBuffer.cpp
@@ -35,22 +35,6 @@ inline void* SafePointerFromUInt(unsigned int handle) {
   return reinterpret_cast<void*>(static_cast<uintptr_t>(handle));
 }
 
-inline unsigned int SafeUIntFromPointer(const void* ptr) {
-#if 1
-  // Ignore the assert below to avoid crashing when running older
-  // system images, which might have buggy encoder libraries. Print
-  // an error message though.
-  if (reinterpret_cast<uintptr_t>(ptr) != static_cast<unsigned int>(reinterpret_cast<uintptr_t>(ptr))) {
-    WARNING("Bad generic pointer %p", ptr);
-  }
-#else
-  // Assertion error if the pointer contains a value that does not fit
-  // in an unsigned integer!
-  assert((uintptr_t)(ptr) == (unsigned int)(uintptr_t)(ptr));
-#endif
-  return static_cast<unsigned int>(reinterpret_cast<uintptr_t>(ptr));
-}
-
 // Lazily create and bind a framebuffer object to the current host context.
 // |fbo| is the address of the framebuffer object name.
 // |tex| is the name of a texture that is attached to the framebuffer object

--- a/src/anbox/graphics/emugl/TextureDraw.cpp
+++ b/src/anbox/graphics/emugl/TextureDraw.cpp
@@ -97,16 +97,13 @@ const GLint kIndicesLen = sizeof(kIndices) / sizeof(kIndices[0]);
 
 }  // namespace
 
-TextureDraw::TextureDraw(EGLDisplay display)
-    : mDisplay(display),
-      mVertexShader(0),
+TextureDraw::TextureDraw(EGLDisplay)
+    : mVertexShader(0),
       mFragmentShader(0),
       mProgram(0),
       mPositionSlot(-1),
       mInCoordSlot(-1),
-      mTextureSlot(-1),
-      mRotationSlot(-1),
-      mTranslationSlot(-1) {
+      mTextureSlot(-1) {
   // Create shaders and program.
   mVertexShader = createShader(GL_VERTEX_SHADER, kVertexShaderSource);
   mFragmentShader = createShader(GL_FRAGMENT_SHADER, kFragmentShaderSource);

--- a/src/anbox/graphics/emugl/TextureDraw.h
+++ b/src/anbox/graphics/emugl/TextureDraw.h
@@ -42,15 +42,12 @@ class TextureDraw {
   bool draw(GLuint texture);
 
  private:
-  EGLDisplay mDisplay;
   GLuint mVertexShader;
   GLuint mFragmentShader;
   GLuint mProgram;
   GLint mPositionSlot;
   GLint mInCoordSlot;
   GLint mTextureSlot;
-  GLint mRotationSlot;
-  GLint mTranslationSlot;
   GLuint mVertexBuffer;
   GLuint mIndexBuffer;
 };

--- a/src/anbox/network/published_socket_connector.cpp
+++ b/src/anbox/network/published_socket_connector.cpp
@@ -33,7 +33,7 @@ PublishedSocketConnector::PublishedSocketConnector(
   start_accept();
 }
 
-PublishedSocketConnector::~PublishedSocketConnector() {}
+PublishedSocketConnector::~PublishedSocketConnector() noexcept {}
 
 void PublishedSocketConnector::start_accept() {
   auto socket = std::make_shared<boost::asio::local::stream_protocol::socket>(runtime_->service());

--- a/src/anbox/network/tcp_socket_connector.cpp
+++ b/src/anbox/network/tcp_socket_connector.cpp
@@ -34,7 +34,7 @@ TcpSocketConnector::TcpSocketConnector(
   start_accept();
 }
 
-TcpSocketConnector::~TcpSocketConnector() { acceptor_.cancel(); }
+TcpSocketConnector::~TcpSocketConnector() noexcept { acceptor_.cancel(); }
 
 void TcpSocketConnector::start_accept() {
   auto socket =

--- a/src/anbox/qemu/pipe_connection_creator.cpp
+++ b/src/anbox/qemu/pipe_connection_creator.cpp
@@ -73,7 +73,7 @@ PipeConnectionCreator::PipeConnectionCreator(const std::shared_ptr<Renderer> &re
           std::make_shared<network::Connections<network::SocketConnection>>()) {
 }
 
-PipeConnectionCreator::~PipeConnectionCreator() {
+PipeConnectionCreator::~PipeConnectionCreator() noexcept {
   connections_->clear();
 }
 

--- a/src/anbox/rpc/connection_creator.cpp
+++ b/src/anbox/rpc/connection_creator.cpp
@@ -34,7 +34,7 @@ ConnectionCreator::ConnectionCreator(const std::shared_ptr<Runtime>& rt,
           std::make_shared<network::Connections<network::SocketConnection>>()),
       message_processor_factory_(factory) {}
 
-ConnectionCreator::~ConnectionCreator() {}
+ConnectionCreator::~ConnectionCreator() noexcept {}
 
 void ConnectionCreator::create_connection_for(
     std::shared_ptr<boost::asio::local::stream_protocol::socket> const&

--- a/src/anbox/runtime.cpp
+++ b/src/anbox/runtime.cpp
@@ -57,7 +57,7 @@ Runtime::Runtime(std::uint32_t pool_size)
       strand_{service_},
       keep_alive_{service_} {}
 
-Runtime::~Runtime() {
+Runtime::~Runtime() noexcept(true) {
   try {
     stop();
   } catch (...) {


### PR DESCRIPTION
Fixes building anbox with clang 4.0 -- removes unused declarations,
makes sure a template is visible at first instantiation, makes sure
exception declarations match between headers and implementations

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>