### PR TITLE
Correct permissions for Android IP configuration directory to prevent failing container start

### DIFF
--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -79,6 +79,9 @@ anbox::cmds::ContainerManager::ContainerManager()
       if (!data_path_.empty())
         SystemConfiguration::instance().set_data_path(data_path_);
 
+      if (!fs::exists(data_path_))
+        fs::create_directories(data_path_);
+
       if (!setup_mounts())
         return EXIT_FAILURE;
 

--- a/src/anbox/cmds/launch.cpp
+++ b/src/anbox/cmds/launch.cpp
@@ -130,7 +130,11 @@ anbox::cmds::Launch::Launch()
         }
 
         try {
-          const auto flags = core::posix::StandardStream::stdout | core::posix::StandardStream::stderr;
+          auto flags = core::posix::StandardStream::stdout | core::posix::StandardStream::stderr;
+          // If we have logging enable in debug mode then we allow the child process
+          // to print to stdout/stderr too.
+          if (Log().GetSeverity() == Logger::Severity::kDebug)
+            flags = core::posix::StandardStream::empty;
           auto child = core::posix::fork([&]() {
             auto grandchild = core::posix::exec(exe_path, args, env, flags);
             grandchild.dont_kill_on_cleanup();

--- a/src/anbox/logger.cpp
+++ b/src/anbox/logger.cpp
@@ -64,6 +64,10 @@ struct BoostLogLogger : public anbox::Logger {
     severity_ = severity;
   }
 
+  Severity GetSeverity() override {
+    return severity_;
+  }
+
   void Log(Severity severity, const std::string& message, const boost::optional<Location>& loc) override {
     if (!initialized_) Init();
 

--- a/src/anbox/logger.h
+++ b/src/anbox/logger.h
@@ -51,6 +51,7 @@ class Logger : public DoNotCopyOrMove {
 
   bool SetSeverityFromString(const std::string &severity);
   virtual void SetSeverity(const Severity& severity) = 0;
+  virtual Severity GetSeverity() = 0;
 
   virtual void Log(Severity severity, const std::string& message,
                    const boost::optional<Location>& location) = 0;


### PR DESCRIPTION
With https://github.com/anbox/anbox/pull/251 we started to write out a static IP configuration for the container into /data/misc/ethernet but never changed the permissions of the created directory hierarchy to be owned by our unprivileged user. Because of that services inside the container failed to launch as they couldn't create any files within the same directories.

This PR fixes this by assigning filesystem ownership to our unprivileged user for the relevant directories.