### PR TITLE
Fix build with GCC 7.1

### DIFF
--- a/src/anbox/bridge/platform_api_skeleton.h
+++ b/src/anbox/bridge/platform_api_skeleton.h
@@ -18,6 +18,7 @@
 #ifndef ANBOX_BRIDGE_PLATFORM_SERVER_H_
 #define ANBOX_BRIDGE_PLATFORM_SERVER_H_
 
+#include <functional>
 #include <memory>
 
 namespace google {

--- a/src/anbox/qemu/at_parser.h
+++ b/src/anbox/qemu/at_parser.h
@@ -18,6 +18,7 @@
 #ifndef ANBOX_QEMU_AT_PARSER_H_
 #define ANBOX_QEMU_AT_PARSER_H_
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
From the Porting to [GCC 7][1] page:

> Several C++ Standard Library headers have been changed to no longer include
> the `<functional>` header. As such, C++ programs that used components defined
> in `<functional>` without explicitly including that header will no longer
> compile.

> Previously components such as std::bind and std::function were
> implicitly defined after including unrelated headers such as `<memory>`,
> `<future>`, `<mutex>`, and `<regex>`.
> Correct code should `#include <functional>` to define them.

[1]: https://gcc.gnu.org/gcc-7/porting_to.html

Signed-off-by: Eddie Ringle <eddie@ringle.io>