### PR TITLE
dkms: fix modules build with more kernel versions

### DIFF
--- a/kernel/ashmem/dkms.conf
+++ b/kernel/ashmem/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="anbox-ashmem"
 PACKAGE_VERSION="1"
 CLEAN="make clean"
-MAKE[0]="make all KVERSION=$kernelver"
+MAKE[0]="make all KERNEL_SRC=/lib/modules/$kernelver/build"
 BUILT_MODULE_NAME[0]="ashmem_linux"
 DEST_MODULE_LOCATION[0]="/updates"
 AUTOINSTALL="yes"

--- a/kernel/binder/dkms.conf
+++ b/kernel/binder/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="anbox-binder"
 PACKAGE_VERSION="1"
 CLEAN="make clean"
-MAKE[0]="make all KVERSION=$kernelver"
+MAKE[0]="make all KERNEL_SRC=/lib/modules/$kernelver/build"
 BUILT_MODULE_NAME[0]="binder_linux"
 DEST_MODULE_LOCATION[0]="/updates"
 AUTOINSTALL="yes"


### PR DESCRIPTION
The Makefile for ashmem and binder have this line:
KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
so dkms will always build those modules against running kernel,
even for other kernel version headers. With this commit dkms will
always provide the necessary kernel version.
