### PR TITLE
Update to newer Android image

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -37,8 +37,8 @@ parts:
 
       case "$ARCH" in
         x86_64)
-          IMAGE_PATH="2017/04/12"
-          IMAGE_NAME="android_1_amd64"
+          IMAGE_PATH="2017/07/07"
+          IMAGE_NAME="android_2_amd64"
           ;;
         arm*)
           IMAGE_PATH="2017/06/12"


### PR DESCRIPTION
Changes:

 * Android system log is now dumped into $ANDROID_DATA/system.log so
   it can be accessed without adb and logcat
 * Fix SEGV in art on newer kernels with CVE-2017-1000364 fixed

Fixes #337