### PR TITLE
Allow the use of the system dbus service

### DIFF
--- a/src/anbox/cmds/launch.cpp
+++ b/src/anbox/cmds/launch.cpp
@@ -77,6 +77,9 @@ anbox::cmds::Launch::Launch()
   flag(cli::make_flag(cli::Name{"stack"},
                       cli::Description{"Which window stack the activity should be started on. Possible: default, fullscreen, freeform"},
                       stack_));
+  flag(cli::make_flag(cli::Name{"use-system-dbus"},
+                      cli::Description{"Use system instead of session DBus"},
+                      use_system_dbus_));
 
   action([this](const cli::Command::Context&) {
     if (!intent_.valid()) {
@@ -92,7 +95,11 @@ anbox::cmds::Launch::Launch()
 
     auto rt = Runtime::create();
 
-    auto bus = std::make_shared<core::dbus::Bus>(core::dbus::WellKnownBus::session);
+    auto bus_type = core::dbus::WellKnownBus::session;
+    if (use_system_dbus_)
+        bus_type = core::dbus::WellKnownBus::system;
+
+    auto bus = std::make_shared<core::dbus::Bus>(bus_type);
     bus->install_executor(core::dbus::asio::make_executor(bus, rt->service()));
 
     const auto snap_path = utils::get_env_value("SNAP");

--- a/src/anbox/cmds/launch.h
+++ b/src/anbox/cmds/launch.h
@@ -38,6 +38,7 @@ class Launch : public cli::CommandWithFlagsAndAction {
 
   android::Intent intent_;
   wm::Stack::Id stack_;
+  bool use_system_dbus_ = false;
 };
 }  // namespace cmds
 }  // namespace anbox

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -85,16 +85,9 @@ std::istream& operator>>(std::istream& in, anbox::graphics::GLRendererServer::Co
 }
 }
 
-anbox::cmds::SessionManager::BusFactory anbox::cmds::SessionManager::session_bus_factory() {
-  return []() {
-    return std::make_shared<core::dbus::Bus>(core::dbus::WellKnownBus::session);
-  };
-}
-
-anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
+anbox::cmds::SessionManager::SessionManager()
     : CommandWithFlagsAndAction{cli::Name{"session-manager"}, cli::Usage{"session-manager"},
                                 cli::Description{"Run the the anbox session manager"}},
-      bus_factory_(bus_factory),
       window_size_(default_single_window_size) {
   // Just for the purpose to allow QtMir (or unity8) to find this on our
   // /proc/*/cmdline
@@ -117,6 +110,9 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
   flag(cli::make_flag(cli::Name{"experimental"},
                       cli::Description{"Allows users to use experimental features"},
                       experimental_));
+  flag(cli::make_flag(cli::Name{"use-system-dbus"},
+                      cli::Description{"Use system instead of session DBus"},
+                      use_system_dbus_));
 
   action([this](const cli::Command::Context &) {
     auto trap = core::posix::trap_signals_for_process(
@@ -248,7 +244,11 @@ anbox::cmds::SessionManager::SessionManager(const BusFactory &bus_factory)
       dispatcher->dispatch([&]() { container_->start(container_configuration); });
     }
 
-    auto bus = bus_factory_();
+    auto bus_type = core::dbus::WellKnownBus::session;
+    if (use_system_dbus_)
+        bus_type = core::dbus::WellKnownBus::system;
+
+    auto bus = std::make_shared<core::dbus::Bus>(bus_type);
     bus->install_executor(core::dbus::asio::make_executor(bus, rt->service()));
 
     auto skeleton = anbox::dbus::skeleton::Service::create_for_bus(bus, app_manager);

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -36,21 +36,17 @@ class Client;
 namespace cmds {
 class SessionManager : public cli::CommandWithFlagsAndAction {
  public:
-  typedef std::function<core::dbus::Bus::Ptr()> BusFactory;
-
-  static BusFactory session_bus_factory();
-
-  SessionManager(const BusFactory& bus_factory = session_bus_factory());
+  SessionManager();
 
  private:
   std::shared_ptr<container::Client> container_;
-  BusFactory bus_factory_;
   std::string desktop_file_hint_;
   graphics::GLRendererServer::Config::Driver gles_driver_;
   bool single_window_ = false;
   graphics::Rect window_size_;
   bool standalone_ = false;
   bool experimental_ = false;
+  bool use_system_dbus_ = false;
 };
 }  // namespace cmds
 }  // namespace anbox


### PR DESCRIPTION
This is necessary in some deployments where no session dbus is available.