### PR TITLE
Add support for rootfs mounts via squashfuse

### DIFF
--- a/src/anbox/common/mount_entry.cpp
+++ b/src/anbox/common/mount_entry.cpp
@@ -46,6 +46,16 @@ std::shared_ptr<MountEntry> MountEntry::create(const std::shared_ptr<LoopDevice>
   return entry;
 }
 
+std::shared_ptr<MountEntry> MountEntry::create(const boost::filesystem::path &target) {
+  auto entry = std::shared_ptr<MountEntry>(new MountEntry(target));
+  if (!entry)
+    return nullptr;
+
+  entry->active_ = true;
+
+  return entry;
+}
+
 MountEntry::MountEntry(const boost::filesystem::path &target) :
   active_{false}, target_{target} {}
 

--- a/src/anbox/common/mount_entry.cpp
+++ b/src/anbox/common/mount_entry.cpp
@@ -17,18 +17,23 @@
 
 #include "anbox/common/mount_entry.h"
 #include "anbox/common/loop_device.h"
+#include "anbox/logger.h"
 
 #include <sys/mount.h>
 
 namespace anbox {
 namespace common {
 std::shared_ptr<MountEntry> MountEntry::create(const boost::filesystem::path &src, const boost::filesystem::path &target,
-                                               const std::string &fs_type, unsigned long flags) {
+                                               const std::string &fs_type, unsigned long flags, const std::string &data) {
   auto entry = std::shared_ptr<MountEntry>(new MountEntry(target));
   if (!entry)
     return nullptr;
 
-  if (::mount(src.c_str(), target.c_str(), !fs_type.empty() ? fs_type.c_str() : nullptr, flags, nullptr) != 0)
+  const void *mount_data = nullptr;
+  if (!data.empty())
+    mount_data = reinterpret_cast<const void*>(data.c_str());
+
+  if (::mount(src.c_str(), target.c_str(), !fs_type.empty() ? fs_type.c_str() : nullptr, flags, mount_data) != 0)
     return nullptr;
 
   entry->active_ = true;
@@ -37,8 +42,8 @@ std::shared_ptr<MountEntry> MountEntry::create(const boost::filesystem::path &sr
 }
 
 std::shared_ptr<MountEntry> MountEntry::create(const std::shared_ptr<LoopDevice> &loop, const boost::filesystem::path &target,
-                                               const std::string &fs_type, unsigned long flags) {
-  auto entry = create(loop->path(), target, fs_type, flags);
+                                               const std::string &fs_type, unsigned long flags, const std::string &data) {
+  auto entry = create(loop->path(), target, fs_type, flags, data);
   if (!entry)
     return nullptr;
 

--- a/src/anbox/common/mount_entry.h
+++ b/src/anbox/common/mount_entry.h
@@ -31,6 +31,8 @@ class MountEntry {
   static std::shared_ptr<MountEntry> create(const std::shared_ptr<LoopDevice> &loop, const boost::filesystem::path &target,
                                             const std::string &fs_type = "", unsigned long flags = 0);
 
+  static std::shared_ptr<MountEntry> create(const boost::filesystem::path &target);
+
   ~MountEntry();
 
  private:

--- a/src/anbox/common/mount_entry.h
+++ b/src/anbox/common/mount_entry.h
@@ -26,10 +26,10 @@ class LoopDevice;
 class MountEntry {
  public:
   static std::shared_ptr<MountEntry> create(const boost::filesystem::path &src, const boost::filesystem::path &target,
-                                            const std::string &fs_type = "", unsigned long flags = 0);
+                                            const std::string &fs_type = "", unsigned long flags = 0, const std::string &data = "");
 
   static std::shared_ptr<MountEntry> create(const std::shared_ptr<LoopDevice> &loop, const boost::filesystem::path &target,
-                                            const std::string &fs_type = "", unsigned long flags = 0);
+                                            const std::string &fs_type = "", unsigned long flags = 0, const std::string &data = "");
 
   static std::shared_ptr<MountEntry> create(const boost::filesystem::path &target);
 

--- a/src/anbox/utils.h
+++ b/src/anbox/utils.h
@@ -56,6 +56,8 @@ std::string process_get_exe_path(const pid_t &pid);
 
 bool is_mounted(const std::string &path);
 
+std::string find_program_on_path(const std::string &name);
+
 template <typename... Types>
 static std::string string_format(const std::string &fmt_str, Types &&... args);
 }  // namespace utils


### PR DESCRIPTION
In some environments (containers) we don't have support for loopback devices and therefor the best choice is to use squashfuse. The implementation hands the mount work off to the mount program so we don't have to care about any implementations details of the squashfuse program and leave this entirely up to the existing infrastructure.

The container manager will automatically fallback to use squashfuse when it detects there is no support for loopback devices.