### PR TITLE
snap build: prefer local android.img rather than always download

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -46,30 +46,41 @@ parts:
     build-packages:
       - wget
     install: |
-      IMAGE_PATH=
-      IMAGE_NAME=
-      ARCH=$(uname -m)
+      LOCAL_IMAGE=$SNAPCRAFT_PART_INSTALL/../../../android-images/android.img
 
-      case "$ARCH" in
-        x86_64)
-          IMAGE_PATH="2017/07/13"
-          IMAGE_NAME="android_3_amd64"
-          ;;
-        arm*)
-          IMAGE_PATH="2017/06/12"
-          IMAGE_NAME="android_1_armhf"
-          ;;
-      esac
+      if [ -f $LOCAL_IMAGE ]; then
 
-      if [ -z "$IMAGE_PATH" ] || [ -z "$IMAGE_NAME" ]; then
-        echo "ERROR: Unknown architecture $ARCH"
-        exit 1
+        echo "Using local image $LOCAL_IMAGE"
+        cp $LOCAL_IMAGE $SNAPCRAFT_PART_INSTALL/android.img
+
+      else
+
+        IMAGE_PATH=
+        IMAGE_NAME=
+        ARCH=$(uname -m)
+
+        case "$ARCH" in
+          x86_64)
+            IMAGE_PATH="2017/07/13"
+            IMAGE_NAME="android_3_amd64.img"
+            ;;
+          arm*)
+            IMAGE_PATH="2017/06/12"
+            IMAGE_NAME="android_1_armhf.img"
+            ;;
+          *)
+            echo "ERROR: Unknown architecture $ARCH"
+            exit 1
+            ;;
+        esac
+
+        # FIXME: downloading with a source: field doesn't work as snapcraft
+        # expects the downloaded file to be an archive it can extract.
+        echo "Downloading image..."
+        wget http://build.anbox.io/android-images/$IMAGE_PATH/$IMAGE_NAME
+        mv $IMAGE_NAME $SNAPCRAFT_PART_INSTALL/android.img
+
       fi
-
-      # FIXME: downloading with a source: field doesn't work as snapcraft
-      # expects the downloaded file to be an archive it can extract.
-      wget http://build.anbox.io/android-images/$IMAGE_PATH/$IMAGE_NAME.img
-      mv $IMAGE_NAME.img $SNAPCRAFT_PART_INSTALL/android.img
     prime:
       - android.img
   anbox-common:


### PR DESCRIPTION
Previously we always load android.img from server when building snap.
Now, build with <ANBOX>/android-images/android.img if there is one.