### PR TITLE
cmds: select host as the default GL ES driver

### DIFF
--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -88,6 +88,7 @@ std::istream& operator>>(std::istream& in, anbox::graphics::GLRendererServer::Co
 anbox::cmds::SessionManager::SessionManager()
     : CommandWithFlagsAndAction{cli::Name{"session-manager"}, cli::Usage{"session-manager"},
                                 cli::Description{"Run the the anbox session manager"}},
+      gles_driver_(graphics::GLRendererServer::Config::Driver::Host),
       window_size_(default_single_window_size) {
   // Just for the purpose to allow QtMir (or unity8) to find this on our
   // /proc/*/cmdline


### PR DESCRIPTION
Translator should be rarely used these days. Most environments have a GL ES driver which is enough for our needs around.