### PR TITLE
Recover on adb server killed

### DIFF
--- a/external/android-emugl/host/libs/Translator/EGL/EglOsApi_glx.cpp
+++ b/external/android-emugl/host/libs/Translator/EGL/EglOsApi_glx.cpp
@@ -25,6 +25,10 @@
 #include <string.h>
 #include <X11/Xlib.h>
 #include <GL/glx.h>
+#if defined(Status)
+// undef to address conflict between X11 symbol and protobuf
+#undef Status
+#endif
 
 namespace {
 

--- a/src/anbox/qemu/adb_message_processor.h
+++ b/src/anbox/qemu/adb_message_processor.h
@@ -67,7 +67,6 @@ class AdbMessageProcessor : public network::MessageProcessor {
   std::shared_ptr<network::TcpSocketConnector> host_connector_;
   std::shared_ptr<network::TcpSocketMessenger> host_messenger_;
   std::array<std::uint8_t, 8192> host_buffer_;
-  boost::asio::deadline_timer host_notify_timer_;
   std::unique_lock<std::mutex> lock_;
 
   static std::mutex active_instance_;


### PR DESCRIPTION
This PR makes sure that the adb connection can recover after an "adb kill-server" command.