### PR TITLE
Fix various problems with the session manager startup process

### DIFF
--- a/src/anbox/bridge/android_api_stub.cpp
+++ b/src/anbox/bridge/android_api_stub.cpp
@@ -29,6 +29,10 @@
 
 namespace fs = boost::filesystem;
 
+namespace {
+constexpr const std::chrono::milliseconds default_rpc_call_timeout{5000};
+} // namespace
+
 namespace anbox {
 namespace bridge {
 AndroidApiStub::AndroidApiStub() {}
@@ -103,7 +107,9 @@ void AndroidApiStub::launch(const android::Intent &intent,
       google::protobuf::NewCallback(this, &AndroidApiStub::application_launched,
                                     c.get()));
 
-  launch_wait_handle_.wait_for_all();
+  launch_wait_handle_.wait_for_pending(default_rpc_call_timeout);
+  if (!launch_wait_handle_.has_result())
+    throw std::runtime_error("RPC call timed out");
 
   if (c->response->has_error()) throw std::runtime_error(c->response->error());
 }
@@ -135,7 +141,9 @@ void AndroidApiStub::set_focused_task(const std::int32_t &id) {
                         google::protobuf::NewCallback(
                             this, &AndroidApiStub::focused_task_set, c.get()));
 
-  set_focused_task_handle_.wait_for_all();
+  set_focused_task_handle_.wait_for_pending(default_rpc_call_timeout);
+  if (!set_focused_task_handle_.has_result())
+    throw std::runtime_error("RPC call timed out");
 
   if (c->response->has_error()) throw std::runtime_error(c->response->error());
 }
@@ -162,7 +170,9 @@ void AndroidApiStub::remove_task(const std::int32_t &id) {
                         google::protobuf::NewCallback(
                             this, &AndroidApiStub::task_removed, c.get()));
 
-  remove_task_handle_.wait_for_all();
+  remove_task_handle_.wait_for_pending(default_rpc_call_timeout);
+  if (!remove_task_handle_.has_result())
+    throw std::runtime_error("RPC call timed out");
 
   if (c->response->has_error()) throw std::runtime_error(c->response->error());
 }
@@ -198,7 +208,9 @@ void AndroidApiStub::resize_task(const std::int32_t &id,
                         google::protobuf::NewCallback(
                             this, &AndroidApiStub::task_resized, c.get()));
 
-  resize_task_handle_.wait_for_all();
+  resize_task_handle_.wait_for_pending(default_rpc_call_timeout);
+  if (!resize_task_handle_.has_result())
+    throw std::runtime_error("RPC call timed out");
 
   if (c->response->has_error()) throw std::runtime_error(c->response->error());
 }

--- a/src/anbox/cmds/launch.cpp
+++ b/src/anbox/cmds/launch.cpp
@@ -84,6 +84,8 @@ anbox::cmds::Launch::Launch()
   action([this](const cli::Command::Context&) {
     if (!intent_.valid()) {
       ERROR("The intent you provided is invalid. Please provide a correct launch intent.");
+      ERROR("For example to launch the application manager, run:");
+      ERROR("$ anbox launch --package=org.anbox.appmgr --component=org.anbox.appmgr.AppViewActivity");
       return EXIT_FAILURE;
     }
 

--- a/src/anbox/cmds/launch.cpp
+++ b/src/anbox/cmds/launch.cpp
@@ -38,6 +38,21 @@ namespace {
 const boost::posix_time::seconds max_wait_timeout{240};
 const int max_restart_attempts{3};
 const std::chrono::seconds restart_interval{5};
+
+static int redirect_to_null(int flags, int fd) {
+  int fd2;
+  if ((fd2 = open("/dev/null", flags)) < 0)
+    return -1;
+
+  if (fd2 == fd)
+    return fd;
+
+  if (dup2(fd2, fd) < 0)
+    return -1;
+
+  close(fd2);
+  return fd;
+}
 }
 
 bool anbox::cmds::Launch::try_launch_activity(const std::shared_ptr<dbus::stub::ApplicationManager> &stub) {
@@ -144,12 +159,34 @@ anbox::cmds::Launch::Launch()
         }
 
         try {
-          auto flags = core::posix::StandardStream::stdout | core::posix::StandardStream::stderr;
-          // If we have logging enable in debug mode then we allow the child process
-          // to print to stdout/stderr too.
-          if (Log().GetSeverity() == Logger::Severity::kDebug)
-            flags = core::posix::StandardStream::empty;
+          auto flags = core::posix::StandardStream::empty;
           auto child = core::posix::fork([&]() {
+            // We redirect all in/out/err to /dev/null as they can't be seen
+            // anywhere. All logging output will directly go to syslog as we
+            // will become a session leader below which will get us rid of a
+            // controlling terminal.
+            if (redirect_to_null(O_RDONLY, 0) < 0 ||
+                redirect_to_null(O_WRONLY, 1) < 0 ||
+                redirect_to_null(O_WRONLY, 2) < 0) {
+              ERROR("Failed to redirect stdout/stderr/stdin: %s", strerror(errno));
+              return core::posix::exit::Status::failure;
+            }
+
+            // As we forked one time already we're sure that our process is
+            // not the session leader anymore so we can safely become the
+            // new one and lead the process group.
+            if (setsid() < 0) {
+              ERROR("Failed to become new session leader: %s", strerror(errno));
+              return core::posix::exit::Status::failure;
+            }
+
+            umask(0077);
+
+            if (chdir("/") < 0) {
+              ERROR("Failed to change current directory: %s", strerror(errno));
+              return core::posix::exit::Status::failure;
+            }
+
             auto grandchild = core::posix::exec(exe_path, args, env, flags);
             grandchild.dont_kill_on_cleanup();
             return core::posix::exit::Status::success;

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -133,13 +133,6 @@ anbox::cmds::SessionManager::SessionManager()
       return EXIT_FAILURE;
     }
 
-    // If we're running with the properietary nvidia driver we always
-    // use the host EGL driver as our translation doesn't work here.
-    if (fs::exists("/dev/nvidiactl")) {
-      INFO("Detected properietary nvidia driver; forcing use of the host EGL driver.");
-      gles_driver_ = graphics::GLRendererServer::Config::Driver::Host;
-    }
-
     utils::ensure_paths({
         SystemConfiguration::instance().socket_dir(),
         SystemConfiguration::instance().input_device_dir(),

--- a/src/anbox/dbus/interface.h
+++ b/src/anbox/dbus/interface.h
@@ -39,7 +39,7 @@ struct ApplicationManager {
       typedef anbox::dbus::interface::ApplicationManager Interface;
       typedef void ResultType;
       static inline std::chrono::milliseconds default_timeout() {
-        return std::chrono::seconds{1};
+        return std::chrono::seconds{60};
       }
     };
   };

--- a/src/anbox/graphics/emugl/Renderer.cpp
+++ b/src/anbox/graphics/emugl/Renderer.cpp
@@ -938,13 +938,14 @@ void Renderer::draw(RendererWindow *window, const Renderable &renderable,
 bool Renderer::draw(EGLNativeWindowType native_window,
                     const anbox::graphics::Rect &window_frame,
                     const RenderableList &renderables) {
+
+  std::unique_lock<std::mutex> l(m_lock);
+
   auto w = m_nativeWindows.find(native_window);
   if (w == m_nativeWindows.end()) return false;
 
-  if (!bindWindow_locked(w->second)) {
-    m_lock.unlock();
+  if (!bindWindow_locked(w->second))
     return false;
-  }
 
   setupViewport(w->second, window_frame);
   s_gles2.glViewport(0, 0, window_frame.width(), window_frame.height());
@@ -958,10 +959,6 @@ bool Renderer::draw(EGLNativeWindowType native_window,
   s_egl.eglSwapBuffers(m_eglDisplay, w->second->surface);
 
   unbind_locked();
-
-  m_lock.lock();
-
-  m_lock.unlock();
 
   return false;
 }

--- a/src/anbox/graphics/emugl/Renderer.cpp
+++ b/src/anbox/graphics/emugl/Renderer.cpp
@@ -655,7 +655,7 @@ bool Renderer::bindContext(HandleType p_context, HandleType p_drawSurface,
                             draw ? draw->getEGLSurface() : EGL_NO_SURFACE,
                             read ? read->getEGLSurface() : EGL_NO_SURFACE,
                             ctx ? ctx->getEGLContext() : EGL_NO_CONTEXT)) {
-    ERROR("eglMakeCurrent failed");
+    ERROR("eglMakeCurrent failed: 0x%04x", s_egl.eglGetError());
     return false;
   }
 
@@ -737,7 +737,7 @@ bool Renderer::bind_locked() {
 
   if (!s_egl.eglMakeCurrent(m_eglDisplay, m_pbufSurface, m_pbufSurface,
                             m_pbufContext)) {
-    ERROR("eglMakeCurrent failed");
+    ERROR("eglMakeCurrent failed: 0x%04x", s_egl.eglGetError());
     return false;
   }
 

--- a/src/anbox/ui/splash_screen.cpp
+++ b/src/anbox/ui/splash_screen.cpp
@@ -18,6 +18,7 @@
 #include "anbox/ui/splash_screen.h"
 #include "anbox/config.h"
 #include "anbox/utils.h"
+#include "anbox/logger.h"
 
 #include <SDL2/SDL_image.h>
 
@@ -44,9 +45,15 @@ SplashScreen::SplashScreen() {
   SDL_FillRect(surface, nullptr, SDL_MapRGB(surface->format, 0xee, 0xee, 0xee));
   SDL_UpdateWindowSurface(window_);
 
-  auto renderer = SDL_CreateRenderer(window_, -1, SDL_RENDERER_ACCELERATED);
-  if (!renderer)
-    BOOST_THROW_EXCEPTION(std::runtime_error("Could not create renderer"));
+  auto renderer = SDL_GetRenderer(window_);
+  if (!renderer) {
+    DEBUG("Window has no associated renderer yet, creating one ...");
+    renderer = SDL_CreateRenderer(window_, -1, SDL_RENDERER_ACCELERATED);
+    if (!renderer) {
+      const auto msg = utils::string_format("Could not create renderer: %s", SDL_GetError());
+      BOOST_THROW_EXCEPTION(std::runtime_error(msg));
+    }
+  }
 
   const auto icon_path = utils::string_format("%s/ui/loading-screen.png", SystemConfiguration::instance().resource_dir());
   auto img = IMG_LoadTexture(renderer, icon_path.c_str());


### PR DESCRIPTION
This improves the session manager startup process quite a lot.  Changes in detail are

 * Don't force host GL driver on nvidia platforms anymore; we don't need this as we're using the host GL driver by default now
 * Only attempt to create a SDL renderer when we don't have one already; a SDL window attempts to create a renderer on it's own at times so we check for that and only create one when necessary
 * Print out example launch intent when executed without any argument: people were confused what kind of arguments to provide to the launch command so we're now giving them an example
 * Apply proper daemonization handling for forked session manager: the most important change of this PR. We were lazy in forking of the session manager before and didn't ensured it's properly getting its own process group and becoming the leader of it. This fixes this and also redirects stdout/stderr/stdin to /dev/null so that subsequent users of these are not crashing when they are point to an invalid file descriptor
 * Correct locking when we draw a new frame: Operations inside the Renderer need to take a lock when operating on the EGL context to prevent EGL_BAD_ACCESS errors when eglMakeCurrent is called (context is used in another thread). This now locks correctly when a new frame is drawn.
 * RPC/DBus timeout improvements: We're now using a larger dbus call timeout and also give a timeout of five seconds for RPC calls to the Android container to keep the system operational even when something fails.

Fixes #416, #410, #404, #395, #392, #390, #387, #382, #376, #375, #367, #365, #344, #352, #343, #336, #335, #322, #317, #316, #285, #290, #310, #282, #275, #269 (and a lot more)
