### PR TITLE
anbox: qemu: qemud_message_processor: Handle multiple 'cat'ed messages

### DIFF
--- a/src/anbox/qemu/qemud_message_processor.cpp
+++ b/src/anbox/qemu/qemud_message_processor.cpp
@@ -51,7 +51,6 @@ void QemudMessageProcessor::process_commands() {
 
     unsigned int body_size = 0;
     ::sscanf(header, "%04x", &body_size);
-    if (body_size != buffer_.size() - header_size) break;
 
     std::string command;
     // Make sure we only copy as much bytes as we have to and not more


### PR DESCRIPTION
It is possible for more than one message to be delivered concurrently.
When this happens, messages are concatenated together (end-to-end).
Current code errors out if the total received data is larger than the
known header_size (4) + the body size (reported in the header).
However, when >=2 messages arrive at the same time, the total received
data will be far greater than this.

The current code base actually handles multiple messages perfectly
already, so all we need to do is remove the early return and
everything "just works".

Signed-off-by: Lee Jones <lee.jones@linaro.org>