### PR TITLE
Just waiting 3 seconds when stop container.

### DIFF
--- a/src/anbox/container/management_api_stub.cpp
+++ b/src/anbox/container/management_api_stub.cpp
@@ -24,6 +24,9 @@
 
 namespace anbox {
 namespace container {
+
+const std::chrono::milliseconds ManagementApiStub::stop_waiting_timeout{3000};
+
 ManagementApiStub::ManagementApiStub(
     const std::shared_ptr<rpc::Channel> &channel)
     : channel_(channel) {}
@@ -75,7 +78,9 @@ void ManagementApiStub::stop_container() {
   channel_->call_method("stop_container", &message, c->response.get(),
       google::protobuf::NewCallback(this, &ManagementApiStub::container_stopped, c.get()));
 
-  c->wh.wait_for_all();
+  // If container manager dies before session manager, the session manager
+  // cannot exit if it waits for all, so just wait for 3 seconds.
+  c->wh.wait_for_pending(stop_waiting_timeout);
 
   if (c->response->has_error()) throw std::runtime_error(c->response->error());
 }

--- a/src/anbox/container/management_api_stub.h
+++ b/src/anbox/container/management_api_stub.h
@@ -56,6 +56,7 @@ class ManagementApiStub : public DoNotCopyOrMove {
 
   mutable std::mutex mutex_;
   std::shared_ptr<rpc::Channel> channel_;
+  static const std::chrono::milliseconds stop_waiting_timeout;
 };
 }  // namespace container
 }  // namespace anbox

--- a/src/anbox/qemu/adb_message_processor.cpp
+++ b/src/anbox/qemu/adb_message_processor.cpp
@@ -74,10 +74,11 @@ void AdbMessageProcessor::advance_state() {
 
       if (state_ == closed_by_host) {
         host_connector_.reset();
-        return;
+      } else {
+        wait_for_host_connection();
       }
 
-      wait_for_host_connection();
+      lock_.unlock();
       break;
     case waiting_for_host_connection:
       messenger_->send(reinterpret_cast<const char *>(ok_command.data()),

--- a/src/anbox/qemu/adb_message_processor.cpp
+++ b/src/anbox/qemu/adb_message_processor.cpp
@@ -72,12 +72,12 @@ void AdbMessageProcessor::advance_state() {
       // one is established but will not use it until the active one is closed.
       lock_.lock();
 
-      if (state_ == closed_by_host)
+      if (state_ == closed_by_host) {
         host_connector_.reset();
-      else
-        wait_for_host_connection();
+        return;
+      }
 
-      lock_.unlock();
+      wait_for_host_connection();
       break;
     case waiting_for_host_connection:
       messenger_->send(reinterpret_cast<const char *>(ok_command.data()),

--- a/src/anbox/qemu/adb_message_processor.cpp
+++ b/src/anbox/qemu/adb_message_processor.cpp
@@ -72,11 +72,10 @@ void AdbMessageProcessor::advance_state() {
       // one is established but will not use it until the active one is closed.
       lock_.lock();
 
-      if (state_ == closed_by_host) {
+      if (state_ == closed_by_host)
         host_connector_.reset();
-      } else {
+      else
         wait_for_host_connection();
-      }
 
       lock_.unlock();
       break;


### PR DESCRIPTION
If container manager dies before session manager dying,
the session manager cannot exit if it waits for all.

Signed-off-by: Han Pengfei <hanpfei@gmail.com>