### PR TITLE
Fix compatibility with Boost 1.66

### DIFF
--- a/src/anbox/network/base_socket_messenger.cpp
+++ b/src/anbox/network/base_socket_messenger.cpp
@@ -138,7 +138,7 @@ unsigned short BaseSocketMessenger<stream_protocol>::local_port() const {
 
 template <typename stream_protocol>
 void BaseSocketMessenger<stream_protocol>::set_no_delay() {
-  const auto fd = socket->native();
+  const auto fd = socket->native_handle();
   int flag = 1;
   const auto ret =
       ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY,


### PR DESCRIPTION
Do not use deprecated boost::asio::basic_stream_socket::native() method.