### PR TITLE
Fix narrowing conversion inside {} (Boost 1.66)

### DIFF
--- a/src/anbox/runtime.cpp
+++ b/src/anbox/runtime.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<Runtime> Runtime::create(std::uint32_t pool_size) {
 
 Runtime::Runtime(std::uint32_t pool_size)
     : pool_size_{pool_size},
-      service_{pool_size_},
+      service_{static_cast<int>(pool_size_)},
       strand_{service_},
       keep_alive_{service_} {}
 

--- a/src/anbox/runtime.cpp
+++ b/src/anbox/runtime.cpp
@@ -53,7 +53,13 @@ std::shared_ptr<Runtime> Runtime::create(std::uint32_t pool_size) {
 
 Runtime::Runtime(std::uint32_t pool_size)
     : pool_size_{pool_size},
+      
+      #if BOOST_VERSION == 106600
       service_{static_cast<int>(pool_size_)},
+      #else
+      service_{pool_size_},
+      #endif
+      
       strand_{service_},
       keep_alive_{service_} {}
 

--- a/src/anbox/runtime.cpp
+++ b/src/anbox/runtime.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<Runtime> Runtime::create(std::uint32_t pool_size) {
 Runtime::Runtime(std::uint32_t pool_size)
     : pool_size_{pool_size},
       
-      #if BOOST_VERSION == 106600
+      #if BOOST_VERSION >= 106600
       service_{static_cast<int>(pool_size_)},
       #else
       service_{pool_size_},

--- a/src/anbox/runtime.h
+++ b/src/anbox/runtime.h
@@ -19,6 +19,7 @@
 #define ANBOX_RUNTIME_H_
 
 #include <boost/asio.hpp>
+#include <boost/version.hpp>
 
 #include <memory.h>
 #include <functional>


### PR DESCRIPTION
add static_cast<int>() on pool_size_ casting to avoid narrowing conversion errors