### PR TITLE
fix argument in binder_set_stop_on_user_error

### DIFF
--- a/kernel/binder/binder.c
+++ b/kernel/binder/binder.c
@@ -137,7 +137,7 @@ static DECLARE_WAIT_QUEUE_HEAD(binder_user_error_wait);
 static int binder_stop_on_user_error;
 
 static int binder_set_stop_on_user_error(const char *val,
-					 struct kernel_param *kp)
+					 const struct kernel_param *kp)
 {
 	int ret;
 


### PR DESCRIPTION
binder_set_stop_on_user_error second argument breaks build.
#608 