### PR TITLE
kernel specific patch -- fix argument in binder_set_stop_on_user_error

### DIFF
--- a/kernel/binder/binder.c
+++ b/kernel/binder/binder.c
@@ -137,7 +137,11 @@ static DECLARE_WAIT_QUEUE_HEAD(binder_user_error_wait);
 static int binder_stop_on_user_error;
 
 static int binder_set_stop_on_user_error(const char *val,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
 					 const struct kernel_param *kp)
+#else
+					 struct kernel_param *kp)
+#endif
 {
 	int ret;
 


### PR DESCRIPTION
changes the argument for kernel 4.15 and later.   