### PR TITLE
Update qemud_message_processor.cpp

### DIFF
--- a/src/anbox/qemu/qemud_message_processor.cpp
+++ b/src/anbox/qemu/qemud_message_processor.cpp
@@ -70,7 +70,7 @@ void QemudMessageProcessor::process_commands() {
 
 void QemudMessageProcessor::send_header(const size_t &size) {
   char header[header_size + 1];
-  std::snprintf(header, header_size + 1, "%04lx", size);
+  std::snprintf(header, header_size + 1, "%04x", size);
   messenger_->send(header, header_size);
 }
 


### PR DESCRIPTION
I get the following error when trying to compile:
void anbox::qemu::QemudMessageProcessor::send_header(const size_t&)’:
/home/dan/anbox/src/anbox/qemu/qemud_message_processor.cpp:73:55: error: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 4 has type ‘size_t {aka unsigned int}’ [-Werror=format=]
   std::snprintf(header, header_size + 1, "%04lx", size);

removing the l seems to help