### PR TITLE
scripts: explicitly set linker search path for libpulsecommon-8.0

### DIFF
--- a/scripts/snap-wrapper.sh
+++ b/scripts/snap-wrapper.sh
@@ -35,6 +35,11 @@ export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
 # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
 
+# With recent builds on Ubuntu 16.04 the snap does not find the path to
+# libpulsecommon-8.0.so anymore so we have to teach the linker manually
+# where it can be found
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/pulseaudio
+
 # We set XDG_DATA_HOME to SNAP_USER_COMMON here as this will be the location we will
 # create all our application launchers in. The system application launcher will
 # be configured by our installer to look into this directory for available


### PR DESCRIPTION
Fixes #626 #627 #628 