### PR TITLE
Fix nir shaders memory leak on translator host side

### DIFF
--- a/external/android-emugl/host/tools/emugen/ApiGen.cpp
+++ b/external/android-emugl/host/tools/emugen/ApiGen.cpp
@@ -753,6 +753,10 @@ int ApiGen::genDecoderHeader(const std::string &filename)
 
     fprintf(fp, "#include \"IOStream.h\" \n");
     fprintf(fp, "#include \"%s_%s_context.h\"\n\n\n", m_basename.c_str(), sideString(SERVER_SIDE));
+    if (strcmp(classname.c_str(), "gles2_decoder_context_t") == 0) {
+        fprintf(fp, "\n#include <map>\n");
+        fprintf(fp, "\n#include <mutex>\n");
+    }
     fprintf(fp, "\n#include \"emugl/common/logging.h\"\n");
 
     for (size_t i = 0; i < m_decoderHeaders.size(); i++) {
@@ -763,6 +767,17 @@ int ApiGen::genDecoderHeader(const std::string &filename)
     fprintf(fp, "struct %s : public %s_%s_context_t {\n\n",
             classname.c_str(), m_basename.c_str(), sideString(SERVER_SIDE));
     fprintf(fp, "\tsize_t decode(void *buf, size_t bufsize, IOStream *stream);\n");
+    if (strcmp(classname.c_str(), "gles2_decoder_context_t") == 0){ 
+	fprintf(fp, 
+			"\tvoid freeShader(); \n\
+			\tvoid freeProgram(); \n\
+			\tstd::map<GLuint, GLuint> m_programs; \n\
+			\tstd::map<GLuint, GLuint> m_shaders; \n\
+			\tstd::mutex m_lock; \n\
+		");
+
+
+    }
     fprintf(fp, "\n};\n\n");
     fprintf(fp, "#endif  // GUARD_%s\n", classname.c_str());
 
@@ -834,6 +849,35 @@ int ApiGen::genDecoderImpl(const std::string &filename)
 
     // helper templates
     fprintf(fp, "using namespace emugl;\n\n");
+
+    // glsl shader/program free;
+    if (strcmp(classname.c_str(), "gles2_decoder_context_t") == 0) {
+        fprintf(fp, "void %s::freeShader(){\n", classname.c_str());
+	fprintf(fp, 
+		"                       \n\
+\tauto it = m_shaders.begin();\n\
+\tm_lock.lock();\n\
+\twhile(it != m_shaders.end()) \n\
+\t{\n\
+\t\tthis->glDeleteShader(it->first);\n\
+\t\tit++;\n\
+\t}\n\
+\tm_lock.unlock();\n\
+}\n\n");
+
+        fprintf(fp, "void %s::freeProgram(){\n", classname.c_str());
+	fprintf(fp, 
+		"		\n\
+\tauto it = m_programs.begin(); \n\
+\tm_lock.lock();\n\
+\twhile(it != m_programs.end()) \n\
+\t{\n\
+\t\tthis->glDeleteProgram(it->first);\n\
+\t\tit++;\n\
+\t}\n\
+\tm_lock.unlock();\n\
+}\n\n");
+    }
 
     // decoder switch;
     fprintf(fp, "size_t %s::decode(void *buf, size_t len, IOStream *stream)\n{\n", classname.c_str());
@@ -1161,6 +1205,41 @@ int ApiGen::genDecoderImpl(const std::string &filename)
 
         } // pass;
         fprintf(fp, "\t\t\tSET_LASTCALL(\"%s\");\n", e->name().c_str());
+	if (strcmp(m_basename.c_str(), "gles2") == 0) {
+	    if (strcmp(e->name().c_str(), "glAttachShader") == 0){
+		fprintf(fp, "\n\
+			\t\t\tm_lock.lock();\n\
+			m_shaders.insert({var_shader, 1});\n\
+			m_lock.unlock();\n");
+	    } else if(strcmp(e->name().c_str(), "glDeleteProgram") == 0){
+		fprintf(fp, 
+			"\t\t\tm_lock.lock(); \n"
+			"\t\t\tauto pro = m_programs.find(var_program); \n"
+			"\t\t\tif (pro == m_programs.end()) \n"
+			"\t\t\t{\n"
+			"\t\t\t\tDEBUG(\"This should not happened!\"); \n"
+			"\t\t\t} else { \n"
+			"\t\t\t\tm_programs.erase(pro); \n"
+			"\t\t\t}\n"
+			"\t\t\tm_lock.unlock();\n");
+            } else if(strcmp(e->name().c_str(), "glDeleteShader") == 0){
+		fprintf(fp, 
+			"\t\t\tm_lock.lock(); \n\
+			\t\t\tauto shader = m_shaders.find(var_shader); \n\
+			\t\t\tif (shader == m_shaders.end()) \n\
+			\t\t\t{ \n\
+			\t\t\t\tDEBUG(\"This should not happened!\"); \n\
+			\t\t\t} else { \n\
+			\t\t\t\tm_shaders.erase(shader); \n\
+			\t\t\t} \n\
+			\t\t\tm_lock.unlock(); \n");
+	    } else if(strcmp(e->name().c_str(), "glLinkProgram") == 0){
+		fprintf(fp, "	\n\
+			\t\t\tm_lock.lock();\n\
+			\t\t\tm_programs.insert({var_program, 1});\n\
+			\t\t\tm_lock.unlock();\n");
+	}
+	}
         fprintf(fp, "\t\t\tbreak;\n");
         fprintf(fp, "\t\t}\n");
 

--- a/external/android-emugl/host/tools/emugen/ApiGen.cpp
+++ b/external/android-emugl/host/tools/emugen/ApiGen.cpp
@@ -1215,10 +1215,8 @@ int ApiGen::genDecoderImpl(const std::string &filename)
 		fprintf(fp, 
 			"\t\t\tm_lock.lock(); \n"
 			"\t\t\tauto pro = m_programs.find(var_program); \n"
-			"\t\t\tif (pro == m_programs.end()) \n"
-			"\t\t\t{\n"
-			"\t\t\t\tDEBUG(\"This should not happened!\"); \n"
-			"\t\t\t} else { \n"
+			"\t\t\tif (pro != m_programs.end()) \n"
+			"\t\t\t{ \n"
 			"\t\t\t\tm_programs.erase(pro); \n"
 			"\t\t\t}\n"
 			"\t\t\tm_lock.unlock();\n");
@@ -1226,10 +1224,8 @@ int ApiGen::genDecoderImpl(const std::string &filename)
 		fprintf(fp, 
 			"\t\t\tm_lock.lock(); \n\
 			\t\t\tauto shader = m_shaders.find(var_shader); \n\
-			\t\t\tif (shader == m_shaders.end()) \n\
+			\t\t\tif (shader != m_shaders.end()) \n\
 			\t\t\t{ \n\
-			\t\t\t\tDEBUG(\"This should not happened!\"); \n\
-			\t\t\t} else { \n\
 			\t\t\t\tm_shaders.erase(shader); \n\
 			\t\t\t} \n\
 			\t\t\tm_lock.unlock(); \n");

--- a/external/process-cpp-minimal/include/core/posix/signal.h
+++ b/external/process-cpp-minimal/include/core/posix/signal.h
@@ -100,7 +100,7 @@ protected:
   * @brief Traps the specified signals for the entire process.
   */
 CORE_POSIX_DLL_PUBLIC
-SignalTrap* trap_signals_for_process(
+std::shared_ptr<SignalTrap> trap_signals_for_process(
         std::initializer_list<core::posix::Signal> blocked_signals);
 
 /**

--- a/external/process-cpp-minimal/include/core/posix/signal.h
+++ b/external/process-cpp-minimal/include/core/posix/signal.h
@@ -100,7 +100,7 @@ protected:
   * @brief Traps the specified signals for the entire process.
   */
 CORE_POSIX_DLL_PUBLIC
-std::shared_ptr<SignalTrap> trap_signals_for_process(
+SignalTrap* trap_signals_for_process(
         std::initializer_list<core::posix::Signal> blocked_signals);
 
 /**

--- a/external/process-cpp-minimal/src/core/posix/signal.cpp
+++ b/external/process-cpp-minimal/src/core/posix/signal.cpp
@@ -203,10 +203,12 @@ private:
 };
 }
 
-core::posix::SignalTrap* core::posix::trap_signals_for_process(
+std::shared_ptr<core::posix::SignalTrap> core::posix::trap_signals_for_process(
 	std::initializer_list<core::posix::Signal> blocked_signals)
 {
-    return new impl::SignalTrap(impl::SignalTrap::Scope::process, blocked_signals);
+    return std::make_shared<impl::SignalTrap>(
+                impl::SignalTrap::Scope::process,
+                blocked_signals);
 }
 
 std::shared_ptr<core::posix::SignalTrap> core::posix::trap_signals_for_all_subsequent_threads(

--- a/external/process-cpp-minimal/src/core/posix/signal.cpp
+++ b/external/process-cpp-minimal/src/core/posix/signal.cpp
@@ -203,12 +203,10 @@ private:
 };
 }
 
-std::shared_ptr<core::posix::SignalTrap> core::posix::trap_signals_for_process(
-        std::initializer_list<core::posix::Signal> blocked_signals)
+core::posix::SignalTrap* core::posix::trap_signals_for_process(
+	std::initializer_list<core::posix::Signal> blocked_signals)
 {
-    return std::make_shared<impl::SignalTrap>(
-                impl::SignalTrap::Scope::process,
-                blocked_signals);
+    return new impl::SignalTrap(impl::SignalTrap::Scope::process, blocked_signals);
 }
 
 std::shared_ptr<core::posix::SignalTrap> core::posix::trap_signals_for_all_subsequent_threads(

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -176,9 +176,8 @@ anbox::cmds::SessionManager::SessionManager()
                                      input_manager,
                                      display_frame,
                                      single_window_);
-    if (!platform) {
+    if (!platform) 
       return EXIT_FAILURE;
-    }
 
     auto app_db = std::make_shared<application::Database>();
 

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -131,7 +131,7 @@ anbox::cmds::SessionManager::SessionManager()
                       use_system_dbus_));
 
   action([this](const cli::Command::Context &) {
-    core::posix::SignalTrap* trap = core::posix::trap_signals_for_process(
+    auto trap = core::posix::trap_signals_for_process(
         {core::posix::Signal::sig_term, core::posix::Signal::sig_int});
     trap->signal_raised().connect([trap](const core::posix::Signal &signal) {
       INFO("Signal %i received. Good night.", static_cast<int>(signal));
@@ -139,13 +139,11 @@ anbox::cmds::SessionManager::SessionManager()
     });
 
     if (standalone_ && !experimental_) {
-      delete trap;
       ERROR("Experimental features selected, but --experimental flag not set");
       return EXIT_FAILURE;
     }
 
     if (!fs::exists("/dev/binder") || !fs::exists("/dev/ashmem")) {
-      delete trap;
       ERROR("Failed to start as either binder or ashmem kernel drivers are not loaded");
       return EXIT_FAILURE;
     }
@@ -179,7 +177,6 @@ anbox::cmds::SessionManager::SessionManager()
                                      display_frame,
                                      single_window_);
     if (!platform) {
-      delete trap;
       return EXIT_FAILURE;
     }
 
@@ -287,7 +284,6 @@ anbox::cmds::SessionManager::SessionManager()
 
     rt->stop();
 
-    delete trap;
     return EXIT_SUCCESS;
   });
 }

--- a/src/anbox/graphics/emugl/RenderThread.cpp
+++ b/src/anbox/graphics/emugl/RenderThread.cpp
@@ -84,7 +84,11 @@ intptr_t RenderThread::main() {
       }
 
     } while (progress);
+
   }
+
+  threadInfo.m_gl2Dec.freeShader();
+  threadInfo.m_gl2Dec.freeProgram();
 
   // Release references to the current thread's context/surfaces if any
   renderer_->bindContext(0, 0, 0);


### PR DESCRIPTION
Fix new nir shader memory leaking issue on translator host side, this kind of issue is heavily increasing the memory usage in host side when the application is creating/closing and compiling gles2 nir shader frequently.