### PR TITLE
Use the `z` as print format for `size_t` variable instead of `l` to m…

### DIFF
--- a/src/anbox/qemu/qemud_message_processor.cpp
+++ b/src/anbox/qemu/qemud_message_processor.cpp
@@ -70,7 +70,7 @@ void QemudMessageProcessor::process_commands() {
 
 void QemudMessageProcessor::send_header(const size_t &size) {
   char header[header_size + 1];
-  std::snprintf(header, header_size + 1, "%04lx", size);
+  std::snprintf(header, header_size + 1, "%04zx", size);
   messenger_->send(header, header_size);
 }
 


### PR DESCRIPTION
…ake it platform independent

`l` is a format for `long int`. It accidentally worked on 64 bit architectures, because `long int` has the same length as `size_t` there.
It didn't work on 32 bit architectures, where `size_t` is shorter than `long int`.
Let's use `z`, because that's the proper format for `size_t` -- it works on any platform.