### PR TITLE
Limit snap architectures to amd64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -201,7 +201,6 @@ parts:
       - libboost-thread-dev
       - libcap-dev
       - libdbus-1-dev
-      - libdbus-cpp-dev
       - libegl1-mesa-dev
       - libgles2-mesa-dev
       - libglib2.0-dev
@@ -210,6 +209,7 @@ parts:
       - libproperties-cpp-dev
       - libsdl2-dev
       - libsdl2-image-dev
+      - libsystemd-dev
       - pkg-config
       - protobuf-compiler
     stage-packages:
@@ -217,13 +217,13 @@ parts:
       - libboost-program-options1.58.0
       - libboost-thread1.58.0
       - libdb5.3
-      - libdbus-cpp5
       - libegl1-mesa
       - libgles2-mesa
       - libgl1-mesa-glx
       - libsdl2-2.0-0
       - libsdl2-gfx-1.0-0
       - libsdl2-image-2.0-0
+      - libsystemd0
     prime:
       - usr/bin/anbox
       - usr/share/anbox

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ description: |
   separate the Android system fully from the host.
 confinement: devmode
 grade: devel
+architectures: [amd64]
 
 slots:
   # Depending on in which environment we're running we either need


### PR DESCRIPTION
We only support the snap for amd64 at the moment.