### PR TITLE
Add snap configure hook to allow enable debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ build*/
 parts/
 stage/
 prime/
-snap/
 android-images/
 *.snap
 CMakeLists.txt.user

--- a/scripts/container-manager.sh
+++ b/scripts/container-manager.sh
@@ -43,6 +43,10 @@ start() {
 		$SNAP/sbin/apparmor_parser -r $SNAP/apparmor/anbox-container.aa
 	fi
 
+	if [ -e "$SNAP_COMMON"/.enable_debug ]; then
+		export ANBOX_LOG_LEVEL=debug
+	fi
+
 	exec $AA_EXEC $SNAP/bin/anbox-wrapper.sh container-manager \
 		--data-path=$DATA_PATH \
 		--android-image=$ANDROID_IMG \

--- a/scripts/snap-wrapper.sh
+++ b/scripts/snap-wrapper.sh
@@ -29,4 +29,8 @@ export XDG_DATA_HOME="$SNAP_USER_COMMON/app-data"
 # configured but the actual EGL implementation is missing.
 export __EGL_VENDOR_LIBRARY_DIRS="$SNAP/glvnd"
 
+if [ -e "$SNAP_COMMON"/.enable_debug ]; then
+	export ANBOX_LOG_LEVEL=debug
+fi
+
 exec $SNAP/usr/bin/anbox $@

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$(snapctl get debug.enable)" = true ]; then
+    touch "$SNAP_COMMON"/.enable_debug
+else
+    rm -f "$SNAP_COMMON"/.enable_debug
+fi
+
+exit 0


### PR DESCRIPTION
Can be enabled via `$ snap set anbox debug.enable=true`. To be effective for the container manager it need to be restarted `$ snap restart anbox.container-manager`