### PR TITLE
lxc: bind relevant devices nodes into the container with shifted uid/gid

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,9 @@ add_library(anbox-protobuf
     ${GENERATED_PROTOBUF_RPC_HDRS}
     ${GENERATED_PROTOBUF_CONTAINER_SRCS}
     ${GENERATED_PROTOBUF_CONTAINER_HDRS}
+    anbox/protobuf/anbox_rpc.proto
+    anbox/protobuf/anbox_bridge.proto
+    anbox/protobuf/anbox_container.proto
     anbox/protobuf/google_protobuf_guard.cpp)
 target_link_libraries(anbox-protobuf
     ${PROTOBUF_LITE_LIBRARIES})

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -244,9 +244,13 @@ anbox::cmds::SessionManager::SessionManager()
         {bridge_connector->socket_file(), "/dev/anbox_bridge"},
         {audio_server->socket_file(), "/dev/anbox_audio"},
         {SystemConfiguration::instance().input_device_dir(), "/dev/input"},
-        {"/dev/binder", "/dev/binder"},
-        {"/dev/ashmem", "/dev/ashmem"},
-        {"/dev/fuse", "/dev/fuse"},
+
+      };
+
+      container_configuration.devices = {
+        {"/dev/binder"},
+        {"/dev/ashmem"},
+        {"/dev/fuse"},
       };
 
       dispatcher->dispatch([&]() {

--- a/src/anbox/container/configuration.h
+++ b/src/anbox/container/configuration.h
@@ -18,13 +18,15 @@
 #ifndef ANBOX_CONTAINER_CONFIGURATION_H_
 #define ANBOX_CONTAINER_CONFIGURATION_H_
 
-#include <map>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace anbox {
 namespace container {
 struct Configuration {
-  std::map<std::string, std::string> bind_mounts;
+  std::unordered_map<std::string, std::string> bind_mounts;
+  std::vector<std::string> devices;
 };
 }  // namespace container
 }  // namespace anbox

--- a/src/anbox/container/lxc_container.h
+++ b/src/anbox/container/lxc_container.h
@@ -40,6 +40,7 @@ class LxcContainer : public Container {
   void set_config_item(const std::string &key, const std::string &value);
   void setup_id_maps();
   void setup_network();
+  void add_device(const std::string& device);
 
   State state_;
   lxc_container *container_;

--- a/src/anbox/container/management_api_skeleton.cpp
+++ b/src/anbox/container/management_api_skeleton.cpp
@@ -50,8 +50,12 @@ void ManagementApiSkeleton::start_container(
   const auto configuration = request->configuration();
   for (int n = 0; n < configuration.bind_mounts_size(); n++) {
     const auto bind_mount = configuration.bind_mounts(n);
-    container_configuration.bind_mounts.insert(
-        {bind_mount.source(), bind_mount.target()});
+    container_configuration.bind_mounts.insert({bind_mount.source(), bind_mount.target()});
+  }
+
+  for (int n = 0; n < configuration.devices_size(); n++) {
+    const auto device = configuration.devices(n);
+    container_configuration.devices.push_back(device);
   }
 
   try {

--- a/src/anbox/container/management_api_stub.cpp
+++ b/src/anbox/container/management_api_stub.cpp
@@ -47,6 +47,11 @@ void ManagementApiStub::start_container(const Configuration &configuration) {
 
   message.set_allocated_configuration(message_configuration);
 
+  for (const auto &device : configuration.devices) {
+    auto d = message_configuration->add_devices();
+    *d = device;
+  }
+
   {
     std::lock_guard<decltype(mutex_)> lock(mutex_);
     c->wh.expect_result();

--- a/src/anbox/protobuf/anbox_container.proto
+++ b/src/anbox/protobuf/anbox_container.proto
@@ -8,6 +8,7 @@ message Configuration {
         required string target = 2;
     }
     repeated BindMount bind_mounts = 1;
+    repeated string devices = 2;
 }
 
 message StartContainer {

--- a/src/anbox/system_configuration.cpp
+++ b/src/anbox/system_configuration.cpp
@@ -75,6 +75,10 @@ std::string anbox::SystemConfiguration::container_socket_path() const {
   return path;
 }
 
+std::string anbox::SystemConfiguration::container_devices_dir() const {
+  return (data_path / "devices").string();
+}
+
 std::string anbox::SystemConfiguration::socket_dir() const {
   static std::string dir = anbox::utils::string_format("%s/anbox/sockets", runtime_dir());
   return dir;

--- a/src/anbox/system_configuration.h
+++ b/src/anbox/system_configuration.h
@@ -38,6 +38,7 @@ class SystemConfiguration {
   std::string socket_dir() const;
   std::string container_config_dir() const;
   std::string container_socket_path() const;
+  std::string container_devices_dir() const;
   std::string input_device_dir() const;
   std::string application_item_dir() const;
   std::string resource_dir() const;


### PR DESCRIPTION
The simple bind mount we used before to forward necessary devices nodes
into the Android container missed shifting the uid/gid. Now we recreate
the devices nodes in a private directory and shift the uid/gid correctly
and then bind mount the resulting files into the container. This should
avoid problems we've have seen on some systems with not allowed access
to some of the device nodes.

Maybe a fix for #741 