### PR TITLE
Map UIDs correctly into the container be independent of the UID initiating the container

### DIFF
--- a/scripts/anbox-init.sh
+++ b/scripts/anbox-init.sh
@@ -29,9 +29,5 @@ prepare_filesystem &
 echo "Waiting for filesystem being prepared ..."
 wait $!
 
-ln -sf /dev/sockets/qemu_pipe /dev/qemu_pipe
-ln -sf /dev/sockets/qemud /dev/qemud
-ln -sf /dev/sockets/anbox_bridge /dev/anbox_bridge
-
 echo "Starting real init now ..."
-/init
+exec /init

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -224,6 +224,7 @@ parts:
       - protobuf-compiler
     stage-packages:
       - libboost-log1.58.0
+      - libboost-iostreams1.58.0
       - libboost-program-options1.58.0
       - libboost-thread1.58.0
       - libdb5.3

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -40,6 +40,7 @@ namespace fs = boost::filesystem;
 
 namespace {
 constexpr unsigned int unprivileged_uid{100000};
+constexpr unsigned int android_system_uid{1000};
 constexpr const char *default_container_ip_address{"192.168.250.2"};
 constexpr const std::uint32_t default_container_ip_prefix_length{24};
 constexpr const char *default_host_ip_address{"192.168.250.1"};
@@ -79,14 +80,14 @@ void LxcContainer::setup_id_map() {
   // We need to bind the user id for the one running the client side
   // process as he is the owner of various socket files we bind mount
   // into the container.
-  set_config_item("lxc.id_map", utils::string_format("u %d %d 1", creds_.uid(), creds_.uid()));
-  set_config_item("lxc.id_map", utils::string_format("g %d %d 1", creds_.gid(), creds_.gid()));
+  set_config_item("lxc.id_map", utils::string_format("u %d %d 1", android_system_uid, creds_.uid()));
+  set_config_item("lxc.id_map", utils::string_format("g %d %d 1", android_system_uid, creds_.gid()));
 
-  set_config_item("lxc.id_map", utils::string_format("u %d %d %d", creds_.uid() + 1,
-                                                     base_id + creds_.uid() + 1,
+  set_config_item("lxc.id_map", utils::string_format("u %d %d %d", android_system_uid + 1,
+                                                     base_id + android_system_uid + 1,
                                                      max_id - creds_.uid() - 1));
-  set_config_item("lxc.id_map", utils::string_format("g %d %d %d", creds_.uid() + 1,
-                                                     base_id + creds_.gid() + 1,
+  set_config_item("lxc.id_map", utils::string_format("g %d %d %d", android_system_uid + 1,
+                                                     base_id + android_system_uid + 1,
                                                      max_id - creds_.gid() - 1));
 }
 

--- a/src/anbox/container/lxc_container.h
+++ b/src/anbox/container/lxc_container.h
@@ -38,7 +38,7 @@ class LxcContainer : public Container {
 
  private:
   void set_config_item(const std::string &key, const std::string &value);
-  void setup_id_maps();
+  void setup_id_map();
   void setup_network();
   void add_device(const std::string& device);
 


### PR DESCRIPTION
So far we were always mapping the UID of the current user directly into the container to allow the sockets being accessible inside the container. This only works as long as the UID of the current user is 1000 (as this matches the UID of the Android system user). If the UID is different things break. To fix this we now map the id of the current user always to the one of the system user inside the container. This makes all sockets accessible by the relevant Android system components and also lets us keep the sockets owned by the current user.

Things still break if multiple users on the same system try to use Anbox. This needs to be fixed separately as it involves more complex code changes and also migration of existing installations.