### PR TITLE
fix overlay lowerdir order

### DIFF
--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -240,7 +240,7 @@ bool anbox::cmds::ContainerManager::setup_rootfs_overlay() {
     fs::create_directories(overlay_path);
 
   const auto rootfs_path = SystemConfiguration::instance().rootfs_dir();
-  const auto overlay_config = utils::string_format("lowerdir=%s:%s", rootfs_path, overlay_path);
+  const auto overlay_config = utils::string_format("lowerdir=%s:%s", overlay_path, rootfs_path);
   auto m = common::MountEntry::create("overlay", combined_rootfs_path, "overlay", MS_RDONLY, overlay_config.c_str());
   if (!m) {
     ERROR("Failed to setup rootfs overlay");


### PR DESCRIPTION
kernel document says:

Multiple lower layers can now be given using the the colon (":") as a
separator character between the directory names.  For example:

  mount -t overlay overlay -olowerdir=/lower1:/lower2:/lower3 /merged

As the example shows, "upperdir=" and "workdir=" may be omitted.  In
that case the overlay will be read-only.

The specified lower directories will be stacked beginning from the
rightmost one and going left.  In the above example lower1 will be the
top, lower2 the middle and lower3 the bottom layer.

The user directory should be on top, so that user can override the file
in original rootfs image.