### PR TITLE
Check for mandatory CPU features on install

### DIFF
--- a/scripts/snap-wrapper.sh
+++ b/scripts/snap-wrapper.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ "$SNAP_ARCH" == "amd64" ]; then
+if [ "$SNAP_ARCH" = "amd64" ]; then
 	ARCH="x86_64-linux-gnu"
-elif [ "$SNAP_ARCH" == "armhf" ]; then
+elif [ "$SNAP_ARCH" = "armhf" ]; then
 	ARCH="arm-linux-gnueabihf"
 else
 	ARCH="$SNAP_ARCH-linux-gnu"
@@ -11,10 +11,12 @@ fi
 # With recent builds on Ubuntu 16.04 the snap does not find the path to
 # libpulsecommon-8.0.so anymore so we have to teach the linker manually
 # where it can be found
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/pulseaudio
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/pulseaudio"
 
 # liblxc.so.1 is in $SNAP/lib
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/lib
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib"
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH"
 
 # We set XDG_DATA_HOME to SNAP_USER_COMMON here as this will be the location we will
 # create all our application launchers in. The system application launcher will

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# If not all feature checks pass we fail the Anbox installation
+exec $SNAP/bin/desktop-launch $SNAP/bin/anbox-wrapper.sh check-features

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,8 @@ set(SOURCES
     anbox/cmds/version.h
     anbox/cmds/wait_ready.cpp
     anbox/cmds/wait_ready.h
+    anbox/cmds/check_features.cpp
+    anbox/cmds/check_features.h
 
     anbox/common/binary_writer.cpp
     anbox/common/binary_writer.h

--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 Simon Fels <morphis@gravedo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "anbox/cmds/check_features.h"
+
+#include "cpu_features_macros.h"
+#include "cpuinfo_x86.h"
+
+anbox::cmds::CheckFeatures::CheckFeatures()
+    : CommandWithFlagsAndAction{
+          cli::Name{"check-features"}, cli::Usage{"check-features"},
+          cli::Description{"Check that the host system supports all necessary features"}} {
+
+  action([this](const cli::Command::Context&) {
+#if defined(CPU_FEATURES_ARCH_X86)
+    const auto info = cpu_features::GetX86Info();
+    std::vector<std::string> missing_features;
+
+#define CHECK_BOOL(x, name) \
+  if (!x) \
+    missing_features.push_back(name)
+
+    CHECK_BOOL(info.features.sse4_1, "SSE 4.1");
+    CHECK_BOOL(info.features.sse4_2, "SSE 4.2");
+    CHECK_BOOL(info.features.ssse3, "SSSE 3");
+
+    if (missing_features.size() > 0) {
+      std::cerr << "Your computer does not meet the requirements to run Anbox. You're missing" << std::endl
+                << "support for the following features: ";
+
+      for (size_t n = 0; n < missing_features.size(); n++) {
+        const auto feature = missing_features[n];
+        std::cerr << feature;
+        if (n < missing_features.size() - 1)
+          std::cerr << ", ";
+      }
+      std::cerr << std::endl;
+
+      return EXIT_FAILURE;
+    }
+
+    std::cout << "Your computer does meet all requirements to run Anbox" << std::endl;
+
+    return EXIT_SUCCESS;
+#else
+    std::cerr << "You're running Anbox on a not yet supported architecture" << std::endl;
+    return EXIT_FAILURE;
+#endif
+  });
+}

--- a/src/anbox/cmds/check_features.h
+++ b/src/anbox/cmds/check_features.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Simon Fels <morphis@gravedo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef ANBOX_CMDS_CHECK_FEATURES_H_
+#define ANBOX_CMDS_CHECK_FEATURES_H_
+
+#include <functional>
+#include <iostream>
+#include <memory>
+
+#include "anbox/cli.h"
+
+namespace anbox {
+namespace cmds {
+class CheckFeatures : public cli::CommandWithFlagsAndAction {
+ public:
+  CheckFeatures();
+};
+}  // namespace cmds
+}  // namespace anbox
+
+#endif

--- a/src/anbox/cmds/system_info.cpp
+++ b/src/anbox/cmds/system_info.cpp
@@ -119,16 +119,12 @@ class SystemInformation {
   const auto info = cpu_features::GetX86Info();
   if (info.features.aes)
     cpu_info_.features.push_back("aes");
-  if (info.features.ssse3)
-    cpu_info_.features.push_back("ssse3");
-  if (info.features.ssse3)
-    cpu_info_.features.push_back("sse4_1");
   if (info.features.sse4_1)
-    cpu_info_.features.push_back("sse4_2");
+    cpu_info_.features.push_back("sse4_1");
   if (info.features.sse4_2)
-    cpu_info_.features.push_back("avx");
+    cpu_info_.features.push_back("sse4_2");
   if (info.features.avx)
-    cpu_info_.features.push_back("ssse3");
+    cpu_info_.features.push_back("avx");
   if (info.features.avx2)
     cpu_info_.features.push_back("avx2");
 

--- a/src/anbox/daemon.cpp
+++ b/src/anbox/daemon.cpp
@@ -28,6 +28,7 @@
 #include "anbox/cmds/launch.h"
 #include "anbox/cmds/version.h"
 #include "anbox/cmds/wait_ready.h"
+#include "anbox/cmds/check_features.h"
 
 #include <boost/filesystem.hpp>
 
@@ -42,7 +43,8 @@ Daemon::Daemon()
      .command(std::make_shared<cmds::Launch>())
      .command(std::make_shared<cmds::ContainerManager>())
      .command(std::make_shared<cmds::SystemInfo>())
-     .command(std::make_shared<cmds::WaitReady>());
+     .command(std::make_shared<cmds::WaitReady>())
+     .command(std::make_shared<cmds::CheckFeatures>());
 
   Log().Init(anbox::Logger::Severity::kWarning);
 


### PR DESCRIPTION
This will fail the snap installation of any of the features are not supported by the CPU the host system runs on.