### PR TITLE
Make network bridge configurable

### DIFF
--- a/scripts/anbox-bridge.sh
+++ b/scripts/anbox-bridge.sh
@@ -18,6 +18,10 @@
 
 varrun="/run/anbox"
 
+if [ -n "$SNAP_DATA" ]; then
+    varrun="$SNAP_DATA"/network
+fi
+
 BRIDGE="anbox0"
 
 # IPv4

--- a/scripts/anbox-bridge.sh
+++ b/scripts/anbox-bridge.sh
@@ -30,6 +30,25 @@ IPV4_NETMASK="255.255.255.0"
 IPV4_NETWORK="192.168.250.1/24"
 IPV4_NAT="true"
 
+if [ -n "$SNAP" ]; then
+    snap_ipv4_address=$(snapctl get bridge.address)
+    snap_ipv4_netmask=$(snapctl get bridge.netmask)
+    snap_ipv4_network=$(snapctl get bridge.network)
+    snap_enable_nat=$(snapctl get bridge.nat.enable)
+    if [ -n "$snap_ipv4_address" ]; then
+        IPV4_ADDR="$snap_ipv4_address"
+    fi
+    if [ -n "$snap_ipv4_netmask" ]; then
+        IPV4_NETMASK="$snap_ipv4_netmask"
+    fi
+    if [ -n "$snap_ipv4_network" ]; then
+        IPV4_NETWORK="$snap_ipv4_network"
+    fi
+    if [ "$snap_enable_nat" = false ]; then
+        IPV4_NAT="false"
+    fi
+fi
+
 use_iptables_lock="-w"
 iptables -w -L -n > /dev/null 2>&1 || use_iptables_lock=""
 


### PR DESCRIPTION
Can be use like `$ snap set anbox bridge.address=192.168.1.2`

This is only the first half to fix #840. With the config options the bridge configuration can be changed but the network device inside the Android container will still receive the wrong configuration. See https://github.com/anbox/anbox/blob/master/src/anbox/container/lxc_container.cpp#L44 This requires additional changes to change the container configuration according to the bridge configuration.