### PR TITLE
sdl: don't prevent screensaver to systems to suspend properly

### DIFF
--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -42,6 +42,13 @@ Platform::Platform(
     : input_manager_(input_manager),
       event_thread_running_(false),
       single_window_(single_window) {
+
+  // Don't block the screensaver from kicking in. It will be blocked
+  // by the desktop shell already and we don't have to do this again.
+  // If we would leave this enabled it will prevent systems from
+  // suspending correctly.
+  SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
+
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS) < 0) {
     const auto message = utils::string_format("Failed to initialize SDL: %s", SDL_GetError());
     BOOST_THROW_EXCEPTION(std::runtime_error(message));


### PR DESCRIPTION
Fixes #393 