### PR TITLE
container: correctly calculate uid/gid maps

### DIFF
--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -80,8 +80,8 @@ void LxcContainer::setup_id_map() {
   const auto base_id = unprivileged_uid;
   const auto max_id = 65536;
 
-  set_config_item("lxc.idmap", utils::string_format("u 0 %d %d", base_id, creds_.uid() - 1));
-  set_config_item("lxc.idmap", utils::string_format("g 0 %d %d", base_id, creds_.gid() - 1));
+  set_config_item("lxc.idmap", utils::string_format("u 0 %d %d", base_id, android_system_uid - 1));
+  set_config_item("lxc.idmap", utils::string_format("g 0 %d %d", base_id, android_system_uid - 1));
 
   // We need to bind the user id for the one running the client side
   // process as he is the owner of various socket files we bind mount


### PR DESCRIPTION
We were calculating the first range towards the ID of the executing user
which is wrong if we want to map the current user to id 1000 inside the
container. This corrects the code to calculate the first range until
1000-1, assigns 1000 to the current user and then continues to assign
1000+1 to the rest of the high-range ids we have allocated.