### PR TITLE
Do application reset on first store_or_update

### DIFF
--- a/src/anbox/application/database.cpp
+++ b/src/anbox/application/database.cpp
@@ -25,13 +25,15 @@ namespace application {
 const Database::Item Database::Unknown{};
 
 Database::Database() :
-  storage_(std::make_shared<LauncherStorage>(SystemConfiguration::instance().application_item_dir())) {
-  storage_->reset();
-}
+  storage_(std::make_shared<LauncherStorage>(SystemConfiguration::instance().application_item_dir())) {}
 
 Database::~Database() {}
 
 void Database::store_or_update(const Item &item) {
+  if (!done_reset) {
+    storage_->reset();
+    done_reset = true;
+  }
   storage_->add_or_update(item);
   items_[item.package] = item;
 

--- a/src/anbox/application/database.h
+++ b/src/anbox/application/database.h
@@ -51,6 +51,7 @@ class Database {
  private:
   std::shared_ptr<LauncherStorage> storage_;
   std::map<std::string,Item> items_;
+  bool done_reset = false;
 };
 }  // namespace application
 }  // namespace anbox


### PR DESCRIPTION
This keep the desktop icons on anbox bootup until new icons gets added. 

This is mostly for ubuntu touch launcher