### PR TITLE
cmds: allow users to change the container network configuration

### DIFF
--- a/scripts/container-manager.sh
+++ b/scripts/container-manager.sh
@@ -70,6 +70,21 @@ start() {
 		EXTRA_ARGS="$EXTRA_ARGS --privileged"
 	fi
 
+	container_network_address=$(snapctl get container.network.address)
+	if [ -n "$container_network_address" ]; then
+		EXTRA_ARGS="$EXTRA_ARGS --container-network-address=$container_network_address"
+	fi
+
+	container_network_gateway=$(snapctl get container.network.gateway)
+	if [ -n "$container_network_gateway" ]; then
+		EXTRA_ARGS="$EXTRA_ARGS --container-network-gateway=$container_network_gateway"
+	fi
+
+	container_network_dns=$(snapctl get container.network.dns)
+	if [ -n "$container_network_dns" ]; then
+		EXTRA_ARGS="$EXTRA_ARGS --container-network-dns-servers=$container_network_dns"
+	fi
+
 	exec "$SNAP"/bin/anbox-wrapper.sh container-manager \
 		--data-path="$DATA_PATH" \
 		--android-image="$ANDROID_IMG" \

--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -55,6 +55,15 @@ anbox::cmds::ContainerManager::ContainerManager()
   flag(cli::make_flag(cli::Name{"use-rootfs-overlay"},
                       cli::Description{"Use an overlay for the Android rootfs"},
                       enable_rootfs_overlay_));
+  flag(cli::make_flag(cli::Name{"container-network-address"},
+                      cli::Description{"Assign the specified network address to the Android container"},
+                      container_network_address_));
+  flag(cli::make_flag(cli::Name{"container-network-gateway"},
+                      cli::Description{"Assign the specified network gateway to the Android container"},
+                      container_network_gateway_));
+  flag(cli::make_flag(cli::Name{"container-network-dns-servers"},
+                      cli::Description{"Assign the specified DNS servers to the Android container"},
+                      container_network_dns_servers_));
 
   action([&](const cli::Command::Context&) {
     try {
@@ -93,6 +102,12 @@ anbox::cmds::ContainerManager::ContainerManager()
       container::Service::Configuration config;
       config.privileged = privileged_;
       config.rootfs_overlay = enable_rootfs_overlay_;
+      config.container_network_address = container_network_address_;
+      config.container_network_gateway = container_network_gateway_;
+
+      if (container_network_dns_servers_.length() > 0)
+        config.container_network_dns_servers = utils::string_split(container_network_dns_servers_, ',');
+
       auto service = container::Service::create(rt, config);
 
       rt->start();

--- a/src/anbox/cmds/container_manager.h
+++ b/src/anbox/cmds/container_manager.h
@@ -45,6 +45,9 @@ class ContainerManager : public cli::CommandWithFlagsAndAction {
   bool privileged_ = false;
   bool daemon_ = false;
   bool enable_rootfs_overlay_ = false;
+  std::string container_network_address_;
+  std::string container_network_gateway_;
+  std::string container_network_dns_servers_;
 };
 }  // namespace cmds
 }  // namespace anbox

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -45,7 +45,6 @@ constexpr const char *default_container_ip_address{"192.168.250.2"};
 constexpr const std::uint32_t default_container_ip_prefix_length{24};
 constexpr const char *default_host_ip_address{"192.168.250.1"};
 constexpr const char *default_dns_server{"8.8.8.8"};
-constexpr const char *default_console_buffer_size{"256KB"};
 
 constexpr int device_major(__dev_t dev) {
   return int(((dev >> 8) & 0xfff) | ((dev >> 32) & (0xfffff000)));
@@ -58,11 +57,19 @@ constexpr int device_minor(__dev_t dev) {
 
 namespace anbox {
 namespace container {
-LxcContainer::LxcContainer(bool privileged, bool rootfs_overlay, const network::Credentials &creds)
+LxcContainer::LxcContainer(bool privileged,
+                           bool rootfs_overlay,
+                           const std::string& container_network_address,
+                           const std::string &container_network_gateway,
+                           const std::vector<std::string> &container_network_dns_servers,
+                           const network::Credentials &creds)
     : state_(State::inactive),
       container_(nullptr),
       privileged_(privileged),
       rootfs_overlay_(rootfs_overlay),
+      container_network_address_(container_network_address),
+      container_network_gateway_(container_network_gateway),
+      container_network_dns_servers_(container_network_dns_servers),
       creds_(creds) {
   utils::ensure_paths({
       SystemConfiguration::instance().container_config_dir(),
@@ -115,9 +122,22 @@ void LxcContainer::setup_network() {
   android::IpConfigBuilder ip_conf;
   ip_conf.set_version(android::IpConfigBuilder::Version::Version2);
   ip_conf.set_assignment(android::IpConfigBuilder::Assignment::Static);
-  ip_conf.set_link_address(default_container_ip_address, default_container_ip_prefix_length);
+
+  std::string address = default_container_ip_address;
+  if (!container_network_address_.empty())
+    address = container_network_address_;
+  ip_conf.set_link_address(address, default_container_ip_prefix_length);
+
+  std::string gateway = default_host_ip_address;
+  if (!container_network_gateway_.empty())
+    gateway = container_network_gateway_;
   ip_conf.set_gateway(default_host_ip_address);
-  ip_conf.set_dns_servers({default_dns_server});
+
+  if (container_network_dns_servers_.size() > 0)
+    ip_conf.set_dns_servers(container_network_dns_servers_);
+  else
+    ip_conf.set_dns_servers({default_dns_server});
+
   ip_conf.set_id(0);
 
   std::vector<std::uint8_t> buffer(512);

--- a/src/anbox/container/lxc_container.h
+++ b/src/anbox/container/lxc_container.h
@@ -22,6 +22,7 @@
 #include "anbox/network/credentials.h"
 
 #include <string>
+#include <vector>
 
 #include <lxc/lxccontainer.h>
 
@@ -29,7 +30,12 @@ namespace anbox {
 namespace container {
 class LxcContainer : public Container {
  public:
-  LxcContainer(bool privileged, bool rootfs_overlay, const network::Credentials &creds);
+  LxcContainer(bool privileged,
+               bool rootfs_overlay,
+               const std::string &container_network_address,
+               const std::string &container_network_gateway,
+               const std::vector<std::string> &container_network_dns_servers,
+               const network::Credentials &creds);
   ~LxcContainer();
 
   void start(const Configuration &configuration) override;
@@ -46,6 +52,9 @@ class LxcContainer : public Container {
   lxc_container *container_;
   bool privileged_;
   bool rootfs_overlay_;
+  std::string container_network_address_;
+  std::string container_network_gateway_;
+  std::vector<std::string> container_network_dns_servers_;
   network::Credentials creds_;
 };
 }  // namespace container

--- a/src/anbox/container/service.cpp
+++ b/src/anbox/container/service.cpp
@@ -86,7 +86,12 @@ void Service::new_client(std::shared_ptr<boost::asio::local::stream_protocol::so
   auto pending_calls = std::make_shared<rpc::PendingCallCache>();
   auto rpc_channel = std::make_shared<rpc::Channel>(pending_calls, messenger);
   auto server = std::make_shared<container::ManagementApiSkeleton>(
-      pending_calls, std::make_shared<LxcContainer>(config_.privileged, config_.rootfs_overlay, messenger->creds()));
+      pending_calls, std::make_shared<LxcContainer>(config_.privileged,
+                                                    config_.rootfs_overlay,
+                                                    config_.container_network_address,
+                                                    config_.container_network_gateway,
+                                                    config_.container_network_dns_servers,
+                                                    messenger->creds()));
   auto processor = std::make_shared<container::ManagementApiMessageProcessor>(
       messenger, pending_calls, server);
 

--- a/src/anbox/container/service.h
+++ b/src/anbox/container/service.h
@@ -33,6 +33,9 @@ class Service : public std::enable_shared_from_this<Service> {
   struct Configuration {
     bool privileged = false;
     bool rootfs_overlay = true;
+    std::string container_network_address;
+    std::string container_network_gateway;
+    std::vector<std::string> container_network_dns_servers;
   };
 
   static std::shared_ptr<Service> create(const std::shared_ptr<Runtime> &rt,


### PR DESCRIPTION
In some spare situations it might be useful to change the network
configuration of the bridge and with that also the configuration of
the Android container itself. We don't validate the configuration
and just apply it no matter if it ends up with network connectivity
in the container.

Fixes #840 #839

Documentation can be found at https://docs.anbox.io/userguide/advanced/network_configuration.html