### PR TITLE
Fix clang build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ set(C_AND_CXX_WARNINGS "-pedantic -Wall -Wextra")
 set(EXTRA_C_WARNINGS "-Wcast-align -Wcast-qual -Wformat -Wredundant-decls -Wswitch-default")
 set(EXTRA_CXX_WARNINGS "-Wnon-virtual-dtor -Wold-style-cast")
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-private-field")
+  set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-const-variable")
+  set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-lambda-capture")
+endif()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_AND_CXX_WARNINGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_C_WARNINGS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,6 @@ set(C_AND_CXX_WARNINGS "-pedantic -Wall -Wextra")
 set(EXTRA_C_WARNINGS "-Wcast-align -Wcast-qual -Wformat -Wredundant-decls -Wswitch-default")
 set(EXTRA_CXX_WARNINGS "-Wnon-virtual-dtor -Wold-style-cast")
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-const-variable")
-endif()
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_AND_CXX_WARNINGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_C_WARNINGS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ set(EXTRA_CXX_WARNINGS "-Wnon-virtual-dtor -Wold-style-cast")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-const-variable")
-  set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-lambda-capture")
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_AND_CXX_WARNINGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set(EXTRA_C_WARNINGS "-Wcast-align -Wcast-qual -Wformat -Wredundant-decls -Wswit
 set(EXTRA_CXX_WARNINGS "-Wnon-virtual-dtor -Wold-style-cast")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-private-field")
   set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-const-variable")
   set(EXTRA_CXX_WARNINGS "${EXTRA_CXX_WARNINGS} -Wno-error=unused-lambda-capture")
 endif()

--- a/external/cpu_features/CMakeLists.txt
+++ b/external/cpu_features/CMakeLists.txt
@@ -5,6 +5,10 @@ project(CpuFeatures VERSION 0.1.0)
 # ANBOX allow to build in our more strict build environment
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=switch-default -Wno-error=unused-parameter -Wno-error=overflow")
 
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=cast-align")
+endif()
+
 # Default Build Type to be Release
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING

--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -42,7 +42,7 @@ anbox::cmds::CheckFeatures::CheckFeatures()
           cli::Name{"check-features"}, cli::Usage{"check-features"},
           cli::Description{"Check that the host system supports all necessary features"}} {
 
-  action([this](const cli::Command::Context&) {
+  action([](const cli::Command::Context&) {
 #if defined(CPU_FEATURES_ARCH_X86)
     const auto info = cpu_features::GetX86Info();
     std::vector<std::string> missing_features;

--- a/src/anbox/dbus/bus.cpp
+++ b/src/anbox/dbus/bus.cpp
@@ -20,9 +20,7 @@
 
 namespace anbox {
 namespace dbus {
-Bus::Bus(Type type) :
-  type_{type} {
-
+Bus::Bus(Type type) {
   int ret = 0;
   switch (type) {
   case Type::Session:

--- a/src/anbox/dbus/bus.h
+++ b/src/anbox/dbus/bus.h
@@ -48,7 +48,6 @@ class Bus : public DoNotCopyOrMove {
  private:
   void worker_main();
 
-  Type type_;
   sd_bus *bus_ = nullptr;
   std::thread worker_thread_;
   std::atomic_bool running_{false};

--- a/src/anbox/dbus/stub/application_manager.cpp
+++ b/src/anbox/dbus/stub/application_manager.cpp
@@ -114,7 +114,12 @@ void ApplicationManager::launch(const android::Intent &intent,
   if (r < 0)
     throw std::runtime_error("Failed to construct DBus message");
 
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic warning "-Wpragmas"
+  #pragma GCC diagnostic warning "-Wc99-extensions"
   sd_bus_error error = SD_BUS_ERROR_NULL;
+  #pragma GCC diagnostic pop
+
   r = sd_bus_call(bus_->raw(), m, 0, &error, nullptr);
   if (r < 0) {
     const auto msg = utils::string_format("%s", error.message);

--- a/src/anbox/graphics/emugl/RenderApi.cpp
+++ b/src/anbox/graphics/emugl/RenderApi.cpp
@@ -30,7 +30,6 @@ GLESv1Dispatch s_gles1;
 
 namespace {
 constexpr const char *default_egl_lib{"libEGL.so.1"};
-constexpr const char *default_glesv1_lib{"libGLESv1_CM.so.1"};
 constexpr const char *default_glesv2_lib{"libGLESv2.so.2"};
 }
 


### PR DESCRIPTION
This PR fixes two clang build errors. There are still three left but I was unsure how they should be handled since they are warnings for unused variables and i am not familiar with anbox codebase so i can not tell if they are false positives or not.

```
src/anbox/cmds/check_features.cpp:41:11: error: lambda capture 'this' is not used [-Wunused-lambda-capture]
  action([this](const cli::Command::Context&) {
          ^
…
src/anbox/dbus/bus.h:51:8: error: private field 'type_' is not used [-Wunused-private-field]
  Type type_;
       ^
…
/home/raetiacorvus/Documents/aur/anbox-git/src/anbox/src/anbox/graphics/emugl/RenderApi.cpp:33:23: error: unused variable 'default_glesv1_lib' [-Werror,-Wunused-const-variable]
constexpr const char *default_glesv1_lib{"libGLESv1_CM.so.1"};
                      ^
```