### PR TITLE
Update check_features.cpp - Added override for Core i7-720QM

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -36,6 +36,8 @@ std::vector<std::string> cpu_whitelist = {
   "M 460",
   // Intel Celeron N2840
   "N2840",
+  // Intel Core i7 Q720
+  "Q 720",
 };
 } // namespace
 


### PR DESCRIPTION
`snap install` complains
> The CPU of your computer (Intel(R) Core(TM) i7 CPU       Q 720  @ 1.60GHz) does not support all
features Anbox requires.
> It is missing support for the following features: SSE 4.1, SSE 4.2, SSSE 3...

but in `/proc/cpuinfo` 
> ...
> model name	: Intel(R) Core(TM) i7 CPU       Q 720  @ 1.60GHz
> ...
> flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 popcnt lahf_lm pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid dtherm ida