### PR TITLE
Add probot stale configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,34 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 120
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - android
+  - app-support
+  - bug
+  - build
+  - container
+  - distro-support
+  - documentation
+  - duplicate
+  - enhancement
+  - help wanted
+  - kernel
+  - not-snap
+  - question
+  - session manager
+  - sigill
+  - startup
+  - tools
+  - undecided
+  - upstream-bug
+# Label to use when marking an issue as stale
+staleLabel: decaying
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
We want to get issues without activity closed after a while unless they
are marked with specific labels to keep things clean and maintainable.