### PR TITLE
Improve performance

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,6 +168,8 @@ set(SOURCES
     anbox/graphics/multi_window_composer_strategy.h
     anbox/graphics/opengles_message_processor.cpp
     anbox/graphics/opengles_message_processor.h
+    anbox/graphics/opengles_socket_connection.cpp
+    anbox/graphics/opengles_socket_connection.h
     anbox/graphics/primitives.h
     anbox/graphics/program_family.cpp
     anbox/graphics/program_family.h

--- a/src/anbox/graphics/opengles_message_processor.cpp
+++ b/src/anbox/graphics/opengles_message_processor.cpp
@@ -16,8 +16,6 @@
  */
 
 #include "anbox/graphics/opengles_message_processor.h"
-#include "anbox/common/small_vector.h"
-#include "anbox/graphics/buffered_io_stream.h"
 #include "anbox/graphics/emugl/RenderThread.h"
 #include "anbox/logger.h"
 #include "anbox/network/connections.h"
@@ -55,10 +53,9 @@ OpenGlesMessageProcessor::~OpenGlesMessageProcessor() {
 }
 
 bool OpenGlesMessageProcessor::process_data(
-    const std::vector<std::uint8_t> &data) {
+    Buffer &&data) {
   auto stream = std::static_pointer_cast<BufferedIOStream>(stream_);
-  Buffer buffer{data.data(), data.data() + data.size()};
-  stream->post_data(std::move(buffer));
+  stream->post_data(std::move(data));
   return true;
 }
 }  // namespace graphics

--- a/src/anbox/graphics/opengles_message_processor.h
+++ b/src/anbox/graphics/opengles_message_processor.h
@@ -22,6 +22,8 @@
 #include "anbox/network/socket_connection.h"
 #include "anbox/network/socket_messenger.h"
 #include "anbox/runtime.h"
+#include "anbox/common/small_vector.h"
+#include "anbox/graphics/buffered_io_stream.h"
 
 #include <boost/asio.hpp>
 
@@ -41,7 +43,7 @@ class OpenGlesMessageProcessor : public network::MessageProcessor {
       const std::shared_ptr<network::SocketMessenger> &messenger);
   ~OpenGlesMessageProcessor();
 
-  bool process_data(const std::vector<std::uint8_t> &data) override;
+  bool process_data(Buffer &&data) override;
 
  private:
   static std::mutex global_lock;

--- a/src/anbox/graphics/opengles_socket_connection.cpp
+++ b/src/anbox/graphics/opengles_socket_connection.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2018 The UBports project
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Marius Gripsgard <marius@ubports.com>
+ */
+
+#include "anbox/logger.h"
+
+#include "anbox/network/message_receiver.h"
+#include "anbox/network/message_sender.h"
+#include "anbox/graphics/opengles_socket_connection.h"
+#include "anbox/graphics/buffered_io_stream.h"
+
+#include <boost/signals2.hpp>
+#include <boost/throw_exception.hpp>
+
+#include <stdexcept>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+
+namespace ba = boost::asio;
+namespace bs = boost::system;
+
+namespace anbox {
+namespace graphics {
+
+OpenGlesSocketConnection::OpenGlesSocketConnection(
+      std::shared_ptr<network::MessageReceiver> const& message_receiver,
+      std::shared_ptr<network::MessageSender> const& message_sender, int id,
+      std::shared_ptr<network::Connections<network::SocketConnection>> const& connections,
+      std::shared_ptr<network::MessageProcessor> const& processor):
+      SocketConnection(message_receiver,
+                      message_sender, id,
+                      connections, processor) {}
+
+void OpenGlesSocketConnection::read_next_message() {
+  auto callback = std::bind(&OpenGlesSocketConnection::on_read_size, this, std::placeholders::_1, std::placeholders::_2);
+  message_receiver_->async_receive_msg(callback, ba::buffer(buffer_));
+}
+
+void OpenGlesSocketConnection::on_read_size(const boost::system::error_code& error, std::size_t bytes_read) {
+  if (error) {
+    connections_->remove(id());
+    return;
+  }
+
+  Buffer data{};
+  data.resize_noinit(bytes_read);
+
+  // Use memcpy here, its faster then std::copy
+  memcpy(data.data(), buffer_.data(), bytes_read);
+
+  if (processor_->process_data(std::move(data)))
+    read_next_message();
+  else
+      connections_->remove(id());
+}
+}  // namespace anbox
+}  // namespace graphics

--- a/src/anbox/graphics/opengles_socket_connection.h
+++ b/src/anbox/graphics/opengles_socket_connection.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2018 The UBports project
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Marius Gripsgard <marius@ubports.com>
+ */
+
+#ifndef ANBOX_GRAPHICS_OPENGLES_SOCKET_CONNECTION_H_
+#define ANBOX_GRAPHICS_OPENGLES_SOCKET_CONNECTION_H_
+
+#include "anbox/network/connections.h"
+#include "anbox/network/message_processor.h"
+#include "anbox/network/message_receiver.h"
+#include "anbox/network/message_sender.h"
+#include "anbox/network/socket_connection.h"
+#include "anbox/graphics/opengles_message_processor.h"
+
+#include <boost/asio.hpp>
+
+#include <sys/types.h>
+
+namespace anbox {
+namespace graphics {
+class OpenGlesSocketConnection : public network::SocketConnection {
+public:
+  OpenGlesSocketConnection(
+      std::shared_ptr<network::MessageReceiver> const& message_receiver,
+      std::shared_ptr<network::MessageSender> const& message_sender, int id,
+      std::shared_ptr<network::Connections<network::SocketConnection>> const& connections,
+      std::shared_ptr<network::MessageProcessor> const& processor);
+  void read_next_message() override;
+private:
+  void on_read_size(const boost::system::error_code& ec,
+                        std::size_t bytes_read) override;
+};
+}  // namespace anbox
+}  // namespace graphics
+
+#endif

--- a/src/anbox/network/message_processor.h
+++ b/src/anbox/network/message_processor.h
@@ -20,13 +20,15 @@
 
 #include <cstdint>
 #include <vector>
+#include "anbox/common/small_vector.h"
 
 namespace anbox {
 namespace network {
 class MessageProcessor {
  public:
   virtual ~MessageProcessor() {}
-  virtual bool process_data(const std::vector<std::uint8_t> &data) = 0;
+  virtual bool process_data(const std::vector<std::uint8_t> &) { return false; }
+  virtual bool process_data(anbox::common::SmallFixedVector<char, 512> &&) { return false; }
 };
 }  // namespace network
 }  // namespace anbox

--- a/src/anbox/network/socket_connection.h
+++ b/src/anbox/network/socket_connection.h
@@ -38,17 +38,17 @@ class SocketConnection {
       std::shared_ptr<Connections<SocketConnection>> const& connections,
       std::shared_ptr<MessageProcessor> const& processor);
 
-  ~SocketConnection() noexcept;
+  virtual ~SocketConnection() noexcept;
 
   void set_name(const std::string& name) { name_ = name; }
 
   int id() const { return id_; }
 
   void send(char const* data, size_t length);
-  void read_next_message();
+  virtual void read_next_message();
 
- private:
-  void on_read_size(const boost::system::error_code& ec,
+protected:
+  virtual void on_read_size(const boost::system::error_code& ec,
                     std::size_t bytes_read);
 
   std::shared_ptr<MessageReceiver> const message_receiver_;

--- a/src/anbox/qemu/pipe_connection_creator.cpp
+++ b/src/anbox/qemu/pipe_connection_creator.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "anbox/graphics/opengles_message_processor.h"
+#include "anbox/graphics/opengles_socket_connection.h"
 #include "anbox/logger.h"
 #include "anbox/network/local_socket_messenger.h"
 #include "anbox/qemu/adb_message_processor.h"
@@ -86,8 +87,14 @@ void PipeConnectionCreator::create_connection_for(
   if (!processor)
     BOOST_THROW_EXCEPTION(std::runtime_error("Unhandled client type"));
 
-  auto const &connection = std::make_shared<network::SocketConnection>(
-      messenger, messenger, next_id(), connections_, processor);
+  std::shared_ptr<network::SocketConnection> connection;
+  if (type == client_type::opengles)
+    connection = std::make_shared<graphics::OpenGlesSocketConnection>(
+        messenger, messenger, next_id(), connections_, processor);
+  else
+    connection = std::make_shared<network::SocketConnection>(
+        messenger, messenger, next_id(), connections_, processor);
+
   connection->set_name(client_type_to_string(type));
   connections_->add(connection);
   connection->read_next_message();


### PR DESCRIPTION
This removes unnecessary std::copy 

For the amount these functions get called, std copy is way to expensive
to do. This removes the need for buffer to be copied twice, first to a
std::vector then SmallFixedVector. This also directly copies buffer into
a smallVector without the init overhead smallVector's ctor does. This
result is a massive performance boost (at least on arm devices).

Also use memcpy interestingly seems to be faster on arm
devices, on amd64 they seems to be about the same speed.