### PR TITLE
Use anbox-binder

### DIFF
--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -126,7 +126,13 @@ anbox::cmds::SessionManager::SessionManager()
       return EXIT_FAILURE;
     }
 
-    if (!fs::exists("/dev/binder") || !fs::exists("/dev/ashmem")) {
+    auto binder = "/dev/binder";
+    // If available, use own binder to not cause problem with existing binder
+    if (fs::exists("/dev/anbox-binder")) {
+      DEBUG("Using anbox-binder");
+      binder = "/dev/anbox-binder";
+    }
+    if (!fs::exists(binder) || !fs::exists("/dev/ashmem")) {
       ERROR("Failed to start as either binder or ashmem kernel drivers are not loaded");
       return EXIT_FAILURE;
     }

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -251,11 +251,10 @@ anbox::cmds::SessionManager::SessionManager()
         {bridge_connector->socket_file(), "/dev/anbox_bridge"},
         {audio_server->socket_file(), "/dev/anbox_audio"},
         {SystemConfiguration::instance().input_device_dir(), "/dev/input"},
-
       };
 
       container_configuration.devices = {
-        {"/dev/binder", {0666}},
+        {binder, {0666, "dev/binder"}},
         {"/dev/ashmem", {0666}},
         {"/dev/fuse", {0666}},
       };

--- a/src/anbox/container/configuration.h
+++ b/src/anbox/container/configuration.h
@@ -25,6 +25,7 @@ namespace anbox {
 namespace container {
 struct DeviceSpecification {
     uint32_t permission;
+    std::string target_path = "";
 };
 struct Configuration {
   std::unordered_map<std::string, std::string> bind_mounts;

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -232,7 +232,9 @@ void LxcContainer::add_device(const std::string& device, const DeviceSpecificati
 
   auto target_path = device;
   // Strip a leading slash as LXC doesn't like that
-  if (utils::string_starts_with(device, "/"))
+  if (!spec.target_path.empty())
+    target_path = spec.target_path;
+  else if (utils::string_starts_with(device, "/"))
     target_path = device.substr(1, device.length() - 1);
 
   const auto entry = utils::string_format("%s %s none bind,create=file,optional 0 0",

--- a/src/anbox/container/management_api_skeleton.cpp
+++ b/src/anbox/container/management_api_skeleton.cpp
@@ -55,7 +55,7 @@ void ManagementApiSkeleton::start_container(
 
   for (int n = 0; n < configuration.devices_size(); n++) {
     const auto device = configuration.devices(n);
-    container_configuration.devices.insert({device.path(), {device.permission()}});
+    container_configuration.devices.insert({device.path(), {device.permission(), device.target_path()}});
   }
 
   try {

--- a/src/anbox/container/management_api_stub.cpp
+++ b/src/anbox/container/management_api_stub.cpp
@@ -49,6 +49,7 @@ void ManagementApiStub::start_container(const Configuration &configuration) {
     auto device_message = message_configuration->add_devices();
     device_message->set_path(item.first);
     device_message->set_permission(item.second.permission);
+    device_message->set_target_path(item.second.target_path);
   }
 
   message.set_allocated_configuration(message_configuration);

--- a/src/anbox/protobuf/anbox_container.proto
+++ b/src/anbox/protobuf/anbox_container.proto
@@ -10,6 +10,7 @@ message Configuration {
     message Devices {
         required string path = 1;
         required uint32 permission = 2;
+        required string target_path = 3;
     }
     repeated BindMount bind_mounts = 1;
     repeated Devices devices = 2;


### PR DESCRIPTION
If /dev/anbox-binder is available, use that binder to not cause problem with existing binder.

This is mostly UBports specific.