### PR TITLE
Update check_features.cpp - Added override for Intel Xeon E5520

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -38,6 +38,8 @@ std::vector<std::string> cpu_whitelist = {
   "N2840",
   // Intel Pentium T4500
   "T4500", 
+  // Intel Core i7 Q720
+  "Q 720",
   // Intel Xeon E5520
   "E5520"
 };

--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -38,6 +38,10 @@ std::vector<std::string> cpu_whitelist = {
   "N2840",
   // Intel Pentium T4500
   "T4500", 
+  // Intel Core i7 Q720
+  "Q 720",
+  // Intel Xeon E5520
+  "E5520"
 };
 } // namespace
 

--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -38,8 +38,6 @@ std::vector<std::string> cpu_whitelist = {
   "N2840",
   // Intel Pentium T4500
   "T4500", 
-  // Intel Core i7 Q720
-  "Q 720",
   // Intel Xeon E5520
   "E5520"
 };


### PR DESCRIPTION
I am also getting the same SSE error while downloading through `snap install` on a virtual machine with an Intel Xeon Processor:

> The CPU of your computer (Intel(R) Xeon(R) CPU E5520 @ 2.27GHz) does not support all
> features Anbox requires.
> It is missing support for the following features: SSE 4.1, SSE 4.2, SSSE 3

but checking `/proc/cpuinfo` reveals that it supports the features:

> ...
> model name	: Intel(R) Xeon(R) CPU E5520 @ 2.27GHz
> ...
> flags	: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid pni **_ssse3 sse4_1 sse4_2_** x2apic hypervisor lahf_lm pti

I hope adding the following code into the array in `check_features.cpp` could fix the problem:

> // Intel Xeon Processor E5520
> "E5520"