### PR TITLE
cmake: link gtest_main to gmock lib

### DIFF
--- a/cmake/FindGMock.cmake
+++ b/cmake/FindGMock.cmake
@@ -77,7 +77,7 @@ target_link_libraries(gmock INTERFACE ${findgmock_gmock_lib} gtest)
 
 add_library(gmock_main INTERFACE)
 target_include_directories(gmock_main INTERFACE ${GMOCK_INCLUDE_DIRS})
-target_link_libraries(gmock_main INTERFACE ${findgmock_gmock_main_lib} gmock)
+target_link_libraries(gmock_main INTERFACE ${findgmock_gmock_main_lib} gmock gtest_main)
 
 set(GTEST_LIBRARIES gtest)
 set(GTEST_MAIN_LIBRARIES gtest_main)


### PR DESCRIPTION
Starting with googletest 1.8.1, I meet the following error when building
the tests.

```
/usr/bin/ld: ../../../gmock/libgmock_main.a(gmock_main.cc.o): in function `main':
/usr/src/googletest/googlemock/src/gmock_main.cc:52: undefined reference to `testing::InitGoogleMock(int*, char**)'
```

With this patch, I can build it successfully.

Build log: https://buildd.debian.org/status/logs.php?pkg=anbox&arch=amd64