### PR TITLE
Add AMD E-350 processor to the whitelist

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -45,7 +45,9 @@ std::vector<std::string> cpu_whitelist = {
   // Intel Xeon E5520
   "E5520"
   // Intel Core2 Duo T6500
-  "T6500"
+  "T6500",
+  // AMD E-350
+  "E 350"
 };
 } // namespace
 


### PR DESCRIPTION
Hi, I'd like to know if this is the right way to override the "It is missing support for the following features: SSE 4.1, SSE 4.2, SSSE 3" error message, I don't really know the language but after looking at other commits I decided to give it a try. Can somebody please let me know If I did it right? 

Thank you:)