### PR TITLE
dbus: fix stack smashing

### DIFF
--- a/src/anbox/dbus/stub/application_manager.cpp
+++ b/src/anbox/dbus/stub/application_manager.cpp
@@ -40,7 +40,7 @@ ApplicationManager::ApplicationManager(const BusPtr& bus)
 ApplicationManager::~ApplicationManager() {}
 
 void ApplicationManager::update_properties() {
-  bool ready = false;
+  int ready = 0;
   const auto r = sd_bus_get_property_trivial(bus_->raw(),
                                              interface::Service::name(),
                                              interface::Service::path(),


### PR DESCRIPTION
The expected C type of a sd-bus boolean is int and not boolean.
This fixes a possible stack smashing caused by the varying types.

See https://github.com/libratbag/libratbag/issues/433 which had the same
problem.