### PR TITLE
Touch on linux, some fixes

### DIFF
--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -268,7 +268,7 @@ void Platform::process_input_event(const SDL_Event &event) {
 
       window = SDL_GetWindowFromID(focused_sdl_window_id);
       // before SDL 2.0.7 on X11 tfinger coordinates are not normalized
-      if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x>1 || event.tfinger.y>1)) {
+      if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x > 1 || event.tfinger.y > 1)) {
         rel_x = event.tfinger.x;
         rel_y = event.tfinger.y;
       } else {
@@ -322,7 +322,7 @@ void Platform::process_input_event(const SDL_Event &event) {
 
       window = SDL_GetWindowFromID(focused_sdl_window_id);
       // before SDL 2.0.7 on X11 tfinger coordinates are not normalized
-      if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x>1 || event.tfinger.y>1)) {
+      if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x > 1 || event.tfinger.y > 1)) {
         rel_x = event.tfinger.x;
         rel_y = event.tfinger.y;
       } else {

--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -316,8 +316,8 @@ void Platform::process_input_event(const SDL_Event &event) {
 }
 
 bool Platform::calculate_touch_coordinates(const SDL_Event &event,
-                                                 std::int32_t &x,
-                                                 std::int32_t &y) {
+                                           std::int32_t &x,
+                                           std::int32_t &y) {
   std::int32_t rel_x = 0;
   std::int32_t rel_y = 0;
 

--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -211,7 +211,7 @@ void Platform::process_input_event(const SDL_Event &event) {
       if (!single_window_) {
         // As we get only absolute coordindates relative to our window we have to
         // calculate the correct position based on the current focused window
-        window = SDL_GetWindowFromID(focused_sdl_window_id);
+        window = SDL_GetWindowFromID(focused_sdl_window_id_);
         if (!window) break;
 
         SDL_GetWindowPosition(window, &x, &y);
@@ -323,7 +323,7 @@ bool Platform::calculate_touch_coordinates(const SDL_Event &event,
 
   SDL_Window *window = nullptr;
 
-  window = SDL_GetWindowFromID(focused_sdl_window_id);
+  window = SDL_GetWindowFromID(focused_sdl_window_id_);
   // before SDL 2.0.7 on X11 tfinger coordinates are not normalized
   if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x > 1 || event.tfinger.y > 1)) {
     rel_x = event.tfinger.x;
@@ -372,7 +372,7 @@ std::shared_ptr<wm::Window> Platform::create_window(
 
   auto id = next_window_id();
   auto w = std::make_shared<Window>(renderer_, id, task, shared_from_this(), frame, title, !window_size_immutable_);
-  focused_sdl_window_id = w->window_id();
+  focused_sdl_window_id_ = w->window_id();
   windows_.insert({id, w});
   return w;
 }
@@ -393,7 +393,7 @@ void Platform::window_wants_focus(const Window::Id &id) {
   if (w == windows_.end()) return;
 
   if (auto window = w->second.lock()) {
-    focused_sdl_window_id = window->window_id();
+    focused_sdl_window_id_ = window->window_id();
     window_manager_->set_focused_task(window->task());
   }
 }

--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -267,13 +267,19 @@ void Platform::process_input_event(const SDL_Event &event) {
       touch_events.push_back({EV_KEY, BTN_TOOL_FINGER, 1});
 
       window = SDL_GetWindowFromID(event.window.windowID);
-      if (window) {
-        SDL_GetWindowSize(window, &rel_x, &rel_y);
-        rel_x *= event.tfinger.x;
-        rel_y *= event.tfinger.y;
+      // before SDL 2.0.7 on X11 tfinger coordinates are not normalized
+      if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x>1 || event.tfinger.y>1)) {
+        rel_x = event.tfinger.x;
+        rel_y = event.tfinger.y;
       } else {
-        rel_x = display_frame_.width() * event.tfinger.x;
-        rel_y = display_frame_.height() * event.tfinger.y;
+        if (window) {
+          SDL_GetWindowSize(window, &rel_x, &rel_y);
+          rel_x *= event.tfinger.x;
+          rel_y *= event.tfinger.y;
+        } else {
+          rel_x = display_frame_.width() * event.tfinger.x;
+          rel_y = display_frame_.height() * event.tfinger.y;
+        }
       }
 
       if (!single_window_) {
@@ -315,13 +321,19 @@ void Platform::process_input_event(const SDL_Event &event) {
       touch_events.push_back({EV_ABS, ABS_MT_SLOT, 0});
 
       window = SDL_GetWindowFromID(event.window.windowID);
-      if (window) {
-        SDL_GetWindowSize(window, &rel_x, &rel_y);
-        rel_x *= event.tfinger.x;
-        rel_y *= event.tfinger.y;
+      // before SDL 2.0.7 on X11 tfinger coordinates are not normalized
+      if (!SDL_VERSION_ATLEAST(2,0,7) && (event.tfinger.x>1 || event.tfinger.y>1)) {
+        rel_x = event.tfinger.x;
+        rel_y = event.tfinger.y;
       } else {
-        rel_x = display_frame_.width() * event.tfinger.x;
-        rel_y = display_frame_.height() * event.tfinger.y;
+        if (window) {
+          SDL_GetWindowSize(window, &rel_x, &rel_y);
+          rel_x *= event.tfinger.x;
+          rel_y *= event.tfinger.y;
+        } else {
+          rel_x = display_frame_.width() * event.tfinger.x;
+          rel_y = display_frame_.height() * event.tfinger.y;
+        }
       }
 
       if (!single_window_) {

--- a/src/anbox/platform/sdl/platform.h
+++ b/src/anbox/platform/sdl/platform.h
@@ -74,6 +74,9 @@ class Platform : public std::enable_shared_from_this<Platform>,
   void process_events();
   void process_input_event(const SDL_Event &event);
 
+  bool calculate_touch_coordinates(const SDL_Event &event, std::int32_t &x,
+                                   std::int32_t &y);
+
   static Window::Id next_window_id();
 
   std::shared_ptr<Renderer> renderer_;

--- a/src/anbox/platform/sdl/platform.h
+++ b/src/anbox/platform/sdl/platform.h
@@ -91,6 +91,7 @@ class Platform : public std::enable_shared_from_this<Platform>,
   graphics::Rect display_frame_;
   bool window_size_immutable_ = false;
   bool single_window_ = false;
+  std::uint32_t focused_sdl_window_id = 0;
 };
 } // namespace sdl
 } // namespace platform

--- a/src/anbox/platform/sdl/platform.h
+++ b/src/anbox/platform/sdl/platform.h
@@ -94,7 +94,7 @@ class Platform : public std::enable_shared_from_this<Platform>,
   graphics::Rect display_frame_;
   bool window_size_immutable_ = false;
   bool single_window_ = false;
-  std::uint32_t focused_sdl_window_id = 0;
+  std::uint32_t focused_sdl_window_id_ = 0;
 };
 } // namespace sdl
 } // namespace platform


### PR DESCRIPTION
before of SDL 2.0.7 on X11 tfinger coordinates are not normalized, Ubuntu 16.04 use SDL 2.0.4, starting from SDL 2.0.7, SDL normalize the tfinger coordinates in the private fuction xinput2_normalize_touch_coordinates.
The second commit point out that windowID is not a field of SDL_TouchFingerEvent event, and window is always NULL for touch events, so set windowID when the window is created or when the window take input focus