### PR TITLE
Implement audio timing

### DIFF
--- a/android/audio/audio_hw.cpp
+++ b/android/audio/audio_hw.cpp
@@ -180,6 +180,14 @@ static ssize_t out_write(struct audio_stream_out *stream, const void *buffer,
   pthread_mutex_lock(&adev->lock);
   if (out->fd >= 0)
     bytes = write(out->fd, buffer, bytes);
+
+  // wait until session writes the data we sent,
+  // this will block if sink queue is full,
+  // acting as synchronization to time audio
+  int64_t arrived_us;
+  read(out->fd, &arrived_us, sizeof(arrived_us));
+  (void) arrived_us;
+
   pthread_mutex_unlock(&adev->lock);
   return bytes;
 }

--- a/src/anbox/audio/server.cpp
+++ b/src/anbox/audio/server.cpp
@@ -31,8 +31,10 @@ using namespace std::placeholders;
 namespace {
 class AudioForwarder : public anbox::network::MessageProcessor {
  public:
-  AudioForwarder(const std::shared_ptr<anbox::audio::Sink> &sink) :
-    sink_(sink) {
+  AudioForwarder(const std::shared_ptr<anbox::audio::Sink> &sink, 
+                 const std::shared_ptr<anbox::network::LocalSocketMessenger> &messenger) :
+    sink_(sink), 
+    messenger_(messenger) {
   }
 
   bool process_data(const std::vector<std::uint8_t> &data) override {
@@ -42,6 +44,7 @@ class AudioForwarder : public anbox::network::MessageProcessor {
 
  private:
   std::shared_ptr<anbox::audio::Sink> sink_;
+  std::shared_ptr<anbox::network::LocalSocketMessenger> messenger_;
 };
 }
 
@@ -81,7 +84,7 @@ void Server::create_connection_for(std::shared_ptr<boost::asio::basic_stream_soc
 
   switch (client_info.type) {
   case ClientInfo::Type::Playback:
-    processor = std::make_shared<AudioForwarder>(platform_->create_audio_sink());
+    processor = std::make_shared<AudioForwarder>(platform_->create_audio_sink(messenger), messenger);
     break;
   case ClientInfo::Type::Recording:
     break;

--- a/src/anbox/platform/base_platform.h
+++ b/src/anbox/platform/base_platform.h
@@ -20,6 +20,7 @@
 
 #include "anbox/graphics/rect.h"
 #include "anbox/wm/window_state.h"
+#include "anbox/network/local_socket_messenger.h"
 
 #include <memory>
 
@@ -51,7 +52,7 @@ class BasePlatform {
   virtual void set_clipboard_data(const ClipboardData &data) = 0;
   virtual ClipboardData get_clipboard_data() = 0;
 
-  virtual std::shared_ptr<audio::Sink> create_audio_sink() = 0;
+  virtual std::shared_ptr<audio::Sink> create_audio_sink(const std::shared_ptr<anbox::network::LocalSocketMessenger> &messenger) = 0;
   virtual std::shared_ptr<audio::Source> create_audio_source() = 0;
 
   virtual void set_renderer(const std::shared_ptr<Renderer> &renderer) = 0;

--- a/src/anbox/platform/null/platform.cpp
+++ b/src/anbox/platform/null/platform.cpp
@@ -48,7 +48,8 @@ NullPlatform::ClipboardData NullPlatform::get_clipboard_data() {
   return ClipboardData{};
 }
 
-std::shared_ptr<audio::Sink> NullPlatform::create_audio_sink() {
+std::shared_ptr<audio::Sink> NullPlatform::create_audio_sink(const std::shared_ptr<network::LocalSocketMessenger> &messenger) {
+  (void) messenger;
   ERROR("Not implemented");
   return nullptr;
 }

--- a/src/anbox/platform/null/platform.h
+++ b/src/anbox/platform/null/platform.h
@@ -31,7 +31,7 @@ class NullPlatform : public BasePlatform {
       const std::string &title) override;
   void set_clipboard_data(const ClipboardData &data) override;
   ClipboardData get_clipboard_data() override;
-  std::shared_ptr<audio::Sink> create_audio_sink() override;
+  std::shared_ptr<audio::Sink> create_audio_sink(const std::shared_ptr<network::LocalSocketMessenger> &messenger) override;
   std::shared_ptr<audio::Source> create_audio_source() override;
   void set_renderer(const std::shared_ptr<Renderer> &renderer) override;
   void set_window_manager(const std::shared_ptr<wm::Manager> &window_manager) override;

--- a/src/anbox/platform/sdl/audio_sink.cpp
+++ b/src/anbox/platform/sdl/audio_sink.cpp
@@ -29,7 +29,8 @@ const constexpr size_t max_queue_size{16};
 namespace anbox {
 namespace platform {
 namespace sdl {
-AudioSink::AudioSink() :
+AudioSink::AudioSink(const std::shared_ptr<network::LocalSocketMessenger> &messenger) :
+  messenger_(messenger),
   device_id_(0),
   queue_(max_queue_size) {
 }

--- a/src/anbox/platform/sdl/audio_sink.h
+++ b/src/anbox/platform/sdl/audio_sink.h
@@ -21,6 +21,7 @@
 #include "anbox/audio/sink.h"
 #include "anbox/graphics/buffer_queue.h"
 #include "anbox/platform/sdl/sdl_wrapper.h"
+#include "anbox/network/local_socket_messenger.h"
 
 #include <thread>
 
@@ -29,7 +30,7 @@ namespace platform {
 namespace sdl {
 class AudioSink : public audio::Sink {
  public:
-  AudioSink();
+  AudioSink(const std::shared_ptr<network::LocalSocketMessenger> &messenger);
   ~AudioSink();
 
   void write_data(const std::vector<std::uint8_t> &data) override;
@@ -40,7 +41,8 @@ class AudioSink : public audio::Sink {
   void read_data(std::uint8_t *buffer, int size);
 
   static void on_data_requested(void *user_data, std::uint8_t *buffer, int size);
-
+  
+  std::shared_ptr<anbox::network::LocalSocketMessenger> messenger_;
   std::mutex lock_;
   SDL_AudioSpec spec_;
   SDL_AudioDeviceID device_id_;

--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -491,8 +491,8 @@ Platform::ClipboardData Platform::get_clipboard_data() {
   return data;
 }
 
-std::shared_ptr<audio::Sink> Platform::create_audio_sink() {
-  return std::make_shared<AudioSink>();
+std::shared_ptr<audio::Sink> Platform::create_audio_sink(const std::shared_ptr<network::LocalSocketMessenger> &messenger) {
+  return std::make_shared<AudioSink>(messenger);
 }
 
 std::shared_ptr<audio::Source> Platform::create_audio_source() {

--- a/src/anbox/platform/sdl/platform.h
+++ b/src/anbox/platform/sdl/platform.h
@@ -64,7 +64,7 @@ class Platform : public std::enable_shared_from_this<Platform>,
   void set_clipboard_data(const ClipboardData &data) override;
   ClipboardData get_clipboard_data() override;
 
-  std::shared_ptr<audio::Sink> create_audio_sink() override;
+  std::shared_ptr<audio::Sink> create_audio_sink(const std::shared_ptr<network::LocalSocketMessenger> &messenger) override;
   std::shared_ptr<audio::Source> create_audio_source() override;
 
   bool supports_multi_window() const override;


### PR DESCRIPTION
This implements audio timing, although, a little bit in a hacky fashion.
Drastically reduces audio latency from 1-2 seconds to ~46 ms. 
(~23 ms playing, the other ~23 ms in buffer, if I'm not mistaken)

Idea is to block the Android audio thread by reading from the socket after submitting the audio data.
The sink after receiving the data, places it into queue and responds to Android.
If queue is full, then it will block until data is written, delaying audio thread for as long as needed.
