### PR TITLE
Add Intel Core 2 Duo E7500 to the whitelist

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -44,8 +44,10 @@ std::vector<std::string> cpu_whitelist = {
   "Q 720",
   // Intel Xeon E5520
   "E5520"
-  // Intel Core2 Duo T6500
-  "T6500"
+  // Intel Core 2 Duo T6500
+  "T6500",
+  // Intel Core 2 Duo E7500
+  "E7500"
 };
 } // namespace
 


### PR DESCRIPTION
It does support SSE 4.2 instructions, I've checked that.