### PR TITLE
BUG: Outdated instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,9 @@ In order to add the PPA to your Ubuntu system please run the following commands:
 ```
  $ sudo add-apt-repository ppa:morphis/anbox-support
  $ sudo apt update
- $ sudo apt install anbox-modules-dkms
+ $ sudo apt install anbox-modules-dkms 
+# BUG: results in Err:9 http://ppa.launchpad.net/morphis/anbox-support/ubuntu disco Release
+# 404  Not Found [IP: XXX.XXX.XXX.XXX]
 ```
 
 These will add the PPA to your system and install the `anbox-modules-dkms`


### PR DESCRIPTION
Disclaimer: may be debian issue.

Line 41 ( $ sudo apt install anbox-modules-dkms ) requires update.

Results in
```
Err:9 http://ppa.launchpad.net/morphis/anbox-support/ubuntu disco Release
  404  Not Found [IP: XXX.XXX.XXX.XXX]
```

Installs: 
```
deb http://ppa.launchpad.net/morphis/anbox-support/ubuntu disco main
# deb-src http://ppa.launchpad.net/morphis/anbox-support/ubuntu disco main
```

`disco` sane?