### PR TITLE
Vpn fixes

### DIFF
--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -117,7 +117,7 @@ LxcContainer::~LxcContainer() {
 
 void LxcContainer::setup_id_map() {
   const auto base_id = unprivileged_uid;
-  const auto max_id = 65536;
+  const auto max_id = 100000;
 
   set_config_item(lxc_config_idmap_key, utils::string_format("u 0 %d %d", base_id, android_system_uid - 1));
   set_config_item(lxc_config_idmap_key, utils::string_format("g 0 %d %d", base_id, android_system_uid - 1));

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -386,6 +386,7 @@ void LxcContainer::start(const Configuration &configuration) {
   devices.insert({"/dev/tty", {0666}});
   devices.insert({"/dev/urandom", {0666}});
   devices.insert({"/dev/zero", {0666}});
+  devices.insert({"/dev/net/tun", {0660}});
 
   // Remove all left over devices from last time first before
   // creating any new ones


### PR DESCRIPTION
This pull request contains two vpn fixes. First it extends max_id to 100000 to allow insertions of the ip rules required by vpn apps.
And it also inserts /dev/net/tun in the container. This device file needs to be linked from /dev/tun and the owner changed to system:vpn, but I don't know where it should be done. It can be done using anbox.shell on each run anyway:
```
# chown system:vpn /dev/net/tun                                                                                                                           
# ln -s net/tun /dev/tun
```

Wireguard works after these changes but only if the peer endpoint isn't part of allowed-ips, otherwise the wireguard packets will be sent to the tun0 tunnel device instead of eth0.