### PR TITLE
emugl: rebuild generated sources only when needed

### DIFF
--- a/external/android-emugl/host/libs/CMakeLists.txt
+++ b/external/android-emugl/host/libs/CMakeLists.txt
@@ -1,4 +1,23 @@
-set(GENERATED_SOURCES
+FUNCTION(PREPEND var prefix)
+   SET(listVar "")
+   FOREACH(f ${ARGN})
+      LIST(APPEND listVar "${prefix}/${f}")
+   ENDFOREACH(f)
+   SET(${var} "${listVar}" PARENT_SCOPE)
+ENDFUNCTION(PREPEND)
+
+PREPEND(GLHEADERS_SOURCES libOpenGLESDispatch/
+    render_egl_extensions.entries
+    render_egl.entries
+    gles_common.entries
+    gles_extensions.entries
+    gles1_only.entries
+    gles1_extensions.entries
+    gles2_only.entries
+    gles2_extensions.entries
+    gles3_only.entries)
+
+PREPEND(GLHEADERS_GENERATED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/../include/OpenGLESDispatch/
     gles1_extensions_functions.h
     gles1_only_functions.h
     gles2_extensions_functions.h
@@ -6,18 +25,16 @@ set(GENERATED_SOURCES
     gles3_only_functions.h
     gles_common_functions.h
     gles_extensions_functions.h
-    gles_functions.h
     RenderEGL_extensions_functions.h
     RenderEGL_functions.h)
 
-add_custom_target(GLHeaders)
 add_custom_command(
-    TARGET GLHeaders
-    POST_BUILD
+    OUTPUT ${GLHEADERS_GENERATED_SOURCES}
     COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen-emugl-headers.sh ${CMAKE_BINARY_DIR}
+    DEPENDS ${GLHEADERS_SOURCES}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_subdirectory(GLESv1_dec)
-add_subdirectory(GLESv2_dec)
-add_subdirectory(libOpenGLESDispatch)
-add_subdirectory(renderControl_dec)
+include(GLESv1_dec/CMakeLists.txt)
+include(GLESv2_dec/CMakeLists.txt)
+include(libOpenGLESDispatch/CMakeLists.txt)
+include(renderControl_dec/CMakeLists.txt)

--- a/external/android-emugl/host/libs/GLESv1_dec/CMakeLists.txt
+++ b/external/android-emugl/host/libs/GLESv1_dec/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(GENERATED_SOURCES
+set(CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/GLESv1_dec)
+
+PREPEND(GENERATED_SOURCES ${CURRENT_BINARY_DIR}/
     gles1_dec.cpp
     gles1_opcodes.h
     gles1_server_context.cpp)
@@ -6,12 +8,12 @@ set(GENERATED_SOURCES
 add_custom_command(
     OUTPUT ${GENERATED_SOURCES}
     POST_BUILD
-    COMMAND ${CMAKE_BINARY_DIR}/external/android-emugl/host/tools/emugen/emugen
-            -D ${CMAKE_CURRENT_BINARY_DIR} gles1
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND mkdir -p ${CURRENT_BINARY_DIR} && ${CMAKE_BINARY_DIR}/external/android-emugl/host/tools/emugen/emugen
+            -D ${CURRENT_BINARY_DIR} gles1
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     DEPENDS emugen)
 
-set(SOURCES
+PREPEND(SOURCES ${CMAKE_CURRENT_LIST_DIR}/
     GLESv1Decoder.cpp)
 
 if ("${cmake_build_type_lower}" STREQUAL "trace")
@@ -20,6 +22,5 @@ if ("${cmake_build_type_lower}" STREQUAL "trace")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENGL_DEBUG}")
 endif()
 
-add_library(GLESv1_dec STATIC ${SOURCES} ${GENERATED_SOURCES})
-add_dependencies(GLESv1_dec GLHeaders)
+add_library(GLESv1_dec STATIC ${SOURCES} ${GENERATED_SOURCES} ${GLHEADERS_GENERATED_SOURCES})
 target_link_libraries(GLESv1_dec OpenglCodecCommon)

--- a/external/android-emugl/host/libs/GLESv2_dec/CMakeLists.txt
+++ b/external/android-emugl/host/libs/GLESv2_dec/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(GENERATED_SOURCES
+set(CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/GLESv2_dec)
+
+PREPEND(GENERATED_SOURCES ${CURRENT_BINARY_DIR}/
     gles2_dec.cpp
     gles2_opcodes.h
     gles2_server_context.cpp)
@@ -6,12 +8,12 @@ set(GENERATED_SOURCES
 add_custom_command(
     OUTPUT ${GENERATED_SOURCES}
     POST_BUILD
-    COMMAND ${CMAKE_BINARY_DIR}/external/android-emugl/host/tools/emugen/emugen
-            -D ${CMAKE_CURRENT_BINARY_DIR} gles2
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND mkdir -p ${CURRENT_BINARY_DIR} && ${CMAKE_BINARY_DIR}/external/android-emugl/host/tools/emugen/emugen
+            -D ${CURRENT_BINARY_DIR} gles2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     DEPENDS emugen)
 
-set(SOURCES
+PREPEND(SOURCES ${CMAKE_CURRENT_LIST_DIR}/
     GLESv2Decoder.cpp)
 
 if ("${cmake_build_type_lower}" STREQUAL "trace")
@@ -20,6 +22,5 @@ if ("${cmake_build_type_lower}" STREQUAL "trace")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENGL_DEBUG}")
 endif()
 
-add_library(GLESv2_dec STATIC ${SOURCES} ${GENERATED_SOURCES})
-add_dependencies(GLESv2_dec GLHeaders)
+add_library(GLESv2_dec STATIC ${SOURCES} ${GENERATED_SOURCES} ${GLHEADERS_GENERATED_SOURCES})
 target_link_libraries(GLESv2_dec OpenglCodecCommon)

--- a/external/android-emugl/host/libs/libOpenGLESDispatch/CMakeLists.txt
+++ b/external/android-emugl/host/libs/libOpenGLESDispatch/CMakeLists.txt
@@ -1,10 +1,9 @@
-set(SOURCES
+PREPEND(SOURCES ${CMAKE_CURRENT_LIST_DIR}/
     EGLDispatch.cpp
     GLESv2Dispatch.cpp
     GLESv1Dispatch.cpp)
 
-add_library(OpenGLESDispatch STATIC ${SOURCES})
-add_dependencies(OpenGLESDispatch GLHeaders)
+add_library(OpenGLESDispatch STATIC ${SOURCES} ${GLHEADERS_GENERATED_SOURCES})
 target_link_libraries(OpenGLESDispatch
     emugl_common
     GLESv2_dec

--- a/external/android-emugl/host/libs/renderControl_dec/CMakeLists.txt
+++ b/external/android-emugl/host/libs/renderControl_dec/CMakeLists.txt
@@ -1,13 +1,15 @@
-set(GENERATED_SOURCES
+set(CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/GLESv1_dec)
+
+PREPEND(GENERATED_SOURCES ${CURRENT_BINARY_DIR}/
     renderControl_dec.cpp
     renderControl_server_context.cpp)
 
 add_custom_command(
     OUTPUT ${GENERATED_SOURCES}
     POST_BUILD
-    COMMAND ${CMAKE_BINARY_DIR}/external/android-emugl/host/tools/emugen/emugen
-            -D ${CMAKE_CURRENT_BINARY_DIR} renderControl
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND mkdir -p ${CURRENT_BINARY_DIR} && ${CMAKE_BINARY_DIR}/external/android-emugl/host/tools/emugen/emugen
+            -D ${CURRENT_BINARY_DIR} renderControl
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     DEPENDS emugen)
 
 if ("${cmake_build_type_lower}" STREQUAL "trace")


### PR DESCRIPTION
Some improvements to the build system which for example allows you to rerun make after a successful build without causing rebuild of the generated sources and libraries and programs that use them. 