### PR TITLE
Vpn fixes

### DIFF
--- a/scripts/anbox-init.sh
+++ b/scripts/anbox-init.sh
@@ -25,6 +25,11 @@ function prepare_filesystem() {
 		chown system:system /dev/$f
 		chmod 0666 /dev/$f
 	done
+
+	if [ -e "/dev/tun" ] ; then
+		chown system:vpn /dev/tun
+		chmod 0660 /dev/tun
+	fi
 }
 
 prepare_filesystem &

--- a/src/anbox/container/configuration.h
+++ b/src/anbox/container/configuration.h
@@ -26,6 +26,7 @@ namespace anbox {
 namespace container {
 struct DeviceSpecification {
   uint32_t permission;
+  std::string old_device_name = "";
 };
 
 struct Configuration {

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -220,7 +220,12 @@ void LxcContainer::setup_network() {
 
 void LxcContainer::add_device(const std::string& device, const DeviceSpecification& spec) {
   struct stat st;
-  int r = stat(device.c_str(), &st);
+  const std::string *old_device_name;
+  if (!spec.old_device_name.empty())
+    old_device_name = &spec.old_device_name;
+  else
+    old_device_name = &device;
+  int r = stat(old_device_name->c_str(), &st);
   if (r < 0) {
     const auto msg = utils::string_format("Failed to retrieve information about device %s", device);
     throw std::runtime_error(msg);
@@ -386,6 +391,7 @@ void LxcContainer::start(const Configuration &configuration) {
   devices.insert({"/dev/tty", {0666}});
   devices.insert({"/dev/urandom", {0666}});
   devices.insert({"/dev/zero", {0666}});
+  devices.insert({"/dev/tun", {0660, "/dev/net/tun"}});
 
   // Remove all left over devices from last time first before
   // creating any new ones

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -117,7 +117,7 @@ LxcContainer::~LxcContainer() {
 
 void LxcContainer::setup_id_map() {
   const auto base_id = unprivileged_uid;
-  const auto max_id = 65536;
+  const auto max_id = 100000;
 
   set_config_item(lxc_config_idmap_key, utils::string_format("u 0 %d %d", base_id, android_system_uid - 1));
   set_config_item(lxc_config_idmap_key, utils::string_format("g 0 %d %d", base_id, android_system_uid - 1));


### PR DESCRIPTION
This branch contains fixes that are required for (almost) working VPN. The android.img also needs to be recreated with the modified scripts/anbox-init.sh, otherwise you need to manually run the following script on each boot.

```
#!/bin/sh

if [ -e "/dev/tun" ] ; then
	chown system:vpn /dev/tun
	chmod 0660 /dev/tun
fi
```

There is still one known issue, VpnService.protect() doesn't work yet. It means you won't be able to use a VPN service if the remote VPN gateway is covered by the VPN routes. I.e. you can't use a VPN service which inserts a default route.
