### PR TITLE
Suppress EGL warning spam

### DIFF
--- a/scripts/snap-wrapper.sh
+++ b/scripts/snap-wrapper.sh
@@ -31,6 +31,9 @@ export XDG_DATA_HOME="$SNAP_USER_COMMON/app-data"
 # configured but the actual EGL implementation is missing.
 export __EGL_VENDOR_LIBRARY_DIRS="$SNAP/glvnd"
 
+# Suppress "libEGL warning: FIXME: egl/x11 doesn't support front buffer rendering." spam
+export EGL_LOG_LEVEL="fatal"
+
 enable_debug="$(snapctl get debug.enable)"
 if [ "$enable_debug" = true ]; then
 	export ANBOX_LOG_LEVEL=debug


### PR DESCRIPTION
"libEGL warning: FIXME: egl/x11 doesn't support front buffer rendering." floods logs otherwise

#1092 #861