### PR TITLE
Use collapsible section for system-info output in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,9 +7,13 @@
 `sudo /snap/bin/anbox.collect-bug-info `
 
 6. ** Please paste the result of `anbox system-info` below:**
+<details>
+<summary>anbox system-info output</summary>
+
 ```
 [please paste printout of `anbox system-info` here]
 ```
+</details>
 
 **Please describe your problem:**
 


### PR DESCRIPTION
`anbox system-info` usually spans a screen or two, which can be mighty annoying when scrolling down to comments