### PR TITLE
repair build on GCC 8.3.0

### DIFF
--- a/src/anbox/dbus/sd_bus_helpers.h
+++ b/src/anbox/dbus/sd_bus_helpers.h
@@ -27,91 +27,53 @@ namespace sdbus {
 namespace vtable {
 constexpr sd_bus_vtable start(uint64_t flags)
 {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_START;
-  v.flags = flags;
-  v.x.start = decltype(v.x.start){sizeof(sd_bus_vtable)};
-
-  return v;
+  return SD_BUS_VTABLE_START(flags);
 }
 
 constexpr sd_bus_vtable end() {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_END;
-
-  return v;
+  return SD_BUS_VTABLE_END;
 }
 
 constexpr sd_bus_vtable method_o(const char* member, const char* signature,
                                  const char* result,
                                  sd_bus_message_handler_t handler, size_t offset,
                                  uint64_t flags) {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_METHOD;
-  v.flags = flags;
-  v.x.method = decltype(v.x.method){member, signature, result, handler, offset};
-
-  return v;
+  return sd_bus_vtable SD_BUS_METHOD_WITH_OFFSET(member, signature, result, handler, offset, flags);
 }
 
 constexpr sd_bus_vtable method(const char* member, const char* signature,
                                const char* result, sd_bus_message_handler_t handler,
                                uint64_t flags) {
-    return method_o(member, signature, result, handler, 0, flags);
+  return method_o(member, signature, result, handler, 0, flags);
 }
 
 constexpr sd_bus_vtable signal(const char* member, const char* signature, uint64_t flags) {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_SIGNAL;
-  v.flags = flags;
-  v.x.signal = decltype(v.x.signal){member, signature};
-
-  return v;
+  return sd_bus_vtable SD_BUS_SIGNAL(member, signature, flags);
 }
 
 constexpr sd_bus_vtable property(const char* member, const char* signature,
                                  sd_bus_property_get_t get,
                                  uint64_t flags) {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_PROPERTY;
-  v.flags = flags;
-  v.x.property = decltype(v.x.property){member, signature, get, nullptr, 0};
-
-  return v;
+  return sd_bus_vtable SD_BUS_PROPERTY(member, signature, get, 0, flags);
 }
 
 constexpr sd_bus_vtable property(const char* member, const char* signature,
                                  sd_bus_property_get_t get,
                                  sd_bus_property_set_t set,
                                  uint64_t flags) {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_WRITABLE_PROPERTY;
-  v.flags = flags;
-  v.x.property = decltype(v.x.property){member, signature, get, set, 0};
-
-  return v;
+  return sd_bus_vtable SD_BUS_WRITABLE_PROPERTY(member, signature, get, set, 0, flags);
 }
 
 constexpr sd_bus_vtable property_o(const char* member, const char* signature,
                                    size_t offset, uint64_t flags) {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_PROPERTY;
-  v.flags = flags;
-  v.x.property = decltype(v.x.property){member, signature, nullptr, nullptr, offset};
-
-  return v;
+  return sd_bus_vtable SD_BUS_PROPERTY(member, signature, nullptr, offset, flags);
 }
 
 constexpr sd_bus_vtable property_o(const char* member, const char* signature,
                                    sd_bus_property_set_t set, size_t offset,
                                    uint64_t flags)
 {
-  sd_bus_vtable v{};
-  v.type = _SD_BUS_VTABLE_WRITABLE_PROPERTY;
-  v.flags = flags;
-  v.x.property = decltype(v.x.property){member, signature, nullptr, set, offset};
-
-  return v;
+  return sd_bus_vtable SD_BUS_WRITABLE_PROPERTY(member, signature, nullptr, set, offset, flags);
 }
 } // namespace vtable
 } // namespace sd_bus


### PR DESCRIPTION
Use pre-defined macros to fill the systemd structures,
whose uninitialized field might otherwise
cause undefined behavior, as stated in the systemd header.