### PR TITLE
fix(anbox#1153): compile dbus helpers in C

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,7 +142,9 @@ set(SOURCES
     anbox/dbus/bus.h
     anbox/dbus/codecs.h
     anbox/dbus/interface.h
+    anbox/dbus/sd_bus_helpers.c
     anbox/dbus/sd_bus_helpers.h
+    anbox/dbus/sd_bus_helpers.hpp
     anbox/dbus/skeleton/application_manager.cpp
     anbox/dbus/skeleton/application_manager.h
     anbox/dbus/skeleton/service.cpp

--- a/src/anbox/dbus/sd_bus_helpers.c
+++ b/src/anbox/dbus/sd_bus_helpers.c
@@ -15,40 +15,63 @@
  *
  */
 
-#ifndef ANBOX_DBUS_SD_BUS_HELPERS_H_
-#define ANBOX_DBUS_SD_BUS_HELPERS_H_
+#include "sd_bus_helpers.h"
 
-#include <systemd/sd-bus-vtable.h>
+sd_bus_vtable sdbus_vtable_create_start(uint64_t flags) {
+  const sd_bus_vtable start = SD_BUS_VTABLE_START(flags);
+  return start;
+}
 
-sd_bus_vtable sdbus_vtable_create_start(uint64_t flags);
-
-sd_bus_vtable sdbus_vtable_create_end();
+sd_bus_vtable sdbus_vtable_create_end() {
+  const sd_bus_vtable end = SD_BUS_VTABLE_END;
+  return end;
+}
 
 sd_bus_vtable sdbus_vtable_create_method_o(const char* member, const char* signature,
                                            const char* result,
                                            sd_bus_message_handler_t handler, size_t offset,
-                                           uint64_t flags);
+                                           uint64_t flags) {
+  const sd_bus_vtable method_o = SD_BUS_METHOD_WITH_OFFSET(
+      member, signature, result, handler, offset, flags);
+  return method_o;
+}
 
 sd_bus_vtable sdbus_vtable_create_method(const char* member, const char* signature,
                                          const char* result, sd_bus_message_handler_t handler,
-                                         uint64_t flags);
+                                         uint64_t flags) {
+  return sdbus_vtable_create_method_o(member, signature, result, handler, 0, flags);
+}
 
-sd_bus_vtable sdbus_vtable_create_signal(const char* member, const char* signature, uint64_t flags);
+sd_bus_vtable sdbus_vtable_create_signal(const char* member, const char* signature, uint64_t flags) {
+  const sd_bus_vtable signal = SD_BUS_SIGNAL(member, signature, flags);
+  return signal;
+}
 
 sd_bus_vtable sdbus_vtable_create_property(const char* member, const char* signature,
                                            sd_bus_property_get_t get,
-                                           uint64_t flags);
+                                           uint64_t flags) {
+  const sd_bus_vtable property = SD_BUS_PROPERTY(member, signature, get, 0, flags);
+  return property;
+}
 
 sd_bus_vtable sdbus_vtable_create_property_set(const char* member, const char* signature,
                                                sd_bus_property_get_t get,
                                                sd_bus_property_set_t set,
-                                               uint64_t flags);
+                                               uint64_t flags) {
+  const sd_bus_vtable property = SD_BUS_WRITABLE_PROPERTY(member, signature, get, set, 0, flags);
+  return property;
+}
 
 sd_bus_vtable sdbus_vtable_create_property_o(const char* member, const char* signature,
-                                             size_t offset, uint64_t flags);
+                                             size_t offset, uint64_t flags) {
+  const sd_bus_vtable property_o = SD_BUS_PROPERTY(member, signature, NULL, offset, flags);
+  return property_o;
+}
 
 sd_bus_vtable sdbus_vtable_create_property_o_set(const char* member, const char* signature,
                                                  sd_bus_property_set_t set, size_t offset,
-                                                 uint64_t flags);
-
-#endif
+                                                 uint64_t flags) {
+  const sd_bus_vtable property_o = SD_BUS_WRITABLE_PROPERTY(
+      member, signature, NULL, set, offset, flags);
+  return property_o;
+}

--- a/src/anbox/dbus/sd_bus_helpers.hpp
+++ b/src/anbox/dbus/sd_bus_helpers.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Martin Unzner <martin.u@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef ANBOX_DBUS_SD_BUS_HELPERS_HPP_
+#define ANBOX_DBUS_SD_BUS_HELPERS_HPP_
+
+namespace anbox {
+namespace dbus {
+
+extern "C" {
+#include "sd_bus_helpers.h"
+}
+}  // namespace dbus
+}  // namespace anbox
+
+#endif

--- a/src/anbox/dbus/skeleton/application_manager.cpp
+++ b/src/anbox/dbus/skeleton/application_manager.cpp
@@ -17,7 +17,7 @@
 
 #include "anbox/dbus/skeleton/application_manager.h"
 #include "anbox/dbus/interface.h"
-#include "anbox/dbus/sd_bus_helpers.h"
+#include "anbox/dbus/sd_bus_helpers.hpp"
 #include "anbox/android/intent.h"
 #include "anbox/logger.h"
 
@@ -51,10 +51,10 @@ namespace anbox {
 namespace dbus {
 namespace skeleton {
 const sd_bus_vtable ApplicationManager::vtable[] = {
-  sdbus::vtable::start(0),
-  sdbus::vtable::method("Launch", "a{sv}s", "", ApplicationManager::method_launch, SD_BUS_VTABLE_UNPRIVILEGED),
-  sdbus::vtable::property("Ready", "b", ApplicationManager::property_ready_get, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-  sdbus::vtable::end()
+  sdbus_vtable_create_start(0),
+  sdbus_vtable_create_method("Launch", "a{sv}s", "", ApplicationManager::method_launch, SD_BUS_VTABLE_UNPRIVILEGED),
+  sdbus_vtable_create_property("Ready", "b", ApplicationManager::property_ready_get, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+  sdbus_vtable_create_end()
 };
 
 int ApplicationManager::method_launch(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {


### PR DESCRIPTION
This fixes the missing-field-initializers warning
and maintains compatibility with the C++ standard
(which pull request #1137 did not), thus working
also with older compilers that lack C struct initialization.