### PR TITLE
binary_writer.cpp: fix compatibility with boost-1.71.0

### DIFF
--- a/src/anbox/common/binary_writer.cpp
+++ b/src/anbox/common/binary_writer.cpp
@@ -22,6 +22,7 @@
 #include <stdexcept>
 
 #include <boost/endian/buffers.hpp>
+#include <boost/endian/conversion.hpp>
 
 namespace {
 bool is_little_endian() {


### PR DESCRIPTION
With newer boost 1.71.0 with:
https://github.com/boostorg/endian/commit/6b5792647c5c2ffb4a375c9e1dc065e73f324f49#diff-5a08a00b5b1ec741b8b13cf3c1396874

boost/endian/conversion.hpp isn't included by
boost/endian/buffers.hpp and the build fails with:

src/anbox/common/binary_writer.cpp: In member function 'void anbox::common::BinaryWriter::write_uint16(uint16_t)':
src/anbox/common/binary_writer.cpp:52:24: error: 'native_to_big' is not a member of 'boost::endian'
   52 |     v = boost::endian::native_to_big(value);
      |                        ^~~~~~~~~~~~~
src/anbox/common/binary_writer.cpp:55:24: error: 'native_to_little' is not a member of 'boost::endian'
   55 |     v = boost::endian::native_to_little(value);
      |                        ^~~~~~~~~~~~~~~~
src/anbox/common/binary_writer.cpp: In member function 'void anbox::common::BinaryWriter::write_uint32(uint32_t)':
src/anbox/common/binary_writer.cpp:72:24: error: 'native_to_big' is not a member of 'boost::endian'
   72 |     v = boost::endian::native_to_big(value);
      |                        ^~~~~~~~~~~~~
src/anbox/common/binary_writer.cpp:75:24: error: 'native_to_little' is not a member of 'boost::endian'
   75 |     v = boost::endian::native_to_little(value);
      |                        ^~~~~~~~~~~~~~~~

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>