### PR TITLE
fix arm build: avoid including x86-only header from cpu_features on arm

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -19,7 +19,9 @@
 #include "anbox/utils.h"
 
 #include "cpu_features_macros.h"
+#if defined(CPU_FEATURES_ARCH_X86)
 #include "cpuinfo_x86.h"
+#endif
 
 namespace {
 std::vector<std::string> cpu_whitelist = {

--- a/src/anbox/cmds/system_info.cpp
+++ b/src/anbox/cmds/system_info.cpp
@@ -31,7 +31,9 @@
 #include "OpenGLESDispatch/EGLDispatch.h"
 
 #include "cpu_features_macros.h"
+#if defined(CPU_FEATURES_ARCH_X86)
 #include "cpuinfo_x86.h"
+#endif
 
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
It breaks build on Alpine/postmarketOS, and is explicitely an error on more recent version of cpu_features: https://github.com/google/cpu_features/blob/master/include/cpuinfo_x86.h#L207.

protecting the include with `#ifdef` fix the problem, as every use of cpu_features is already protected.