### PR TITLE
input: Ensure sockets are accessible from within the container

### DIFF
--- a/src/anbox/input/device.cpp
+++ b/src/anbox/input/device.cpp
@@ -38,6 +38,10 @@ std::shared_ptr<Device> Device::create(
   sp->connector_ = std::make_shared<network::PublishedSocketConnector>(
       path, runtime, delegate_connector);
 
+  // The socket is created with user permissions (e.g. rwx------),
+  // which prevents the container from accessing it. Make sure it is writable.
+  ::chmod(path.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+
   return sp;
 }
 

--- a/src/anbox/input/manager.cpp
+++ b/src/anbox/input/manager.cpp
@@ -26,7 +26,12 @@
 namespace anbox {
 namespace input {
 Manager::Manager(const std::shared_ptr<Runtime> &runtime) : runtime_(runtime) {
-  utils::ensure_paths({SystemConfiguration::instance().input_device_dir()});
+  const auto dir = SystemConfiguration::instance().input_device_dir();
+  utils::ensure_paths({dir});
+
+  // The directory is bind-mounted into the container but might have user
+  // permissions only (rwx------). Make sure it is accessible.
+  ::chmod(dir.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 }
 
 Manager::~Manager() {}


### PR DESCRIPTION
The input sockets are created within the user tmpfs (e.g. /run/user/...).
Files/sockets created there might not be accessible to other users.
Since the input sockets are bind-mounted into the Android container,
it will crash with "Permission denied" when it is unable to access them.

Make sure to give the created directory+socket files appropriate
permissions so they can be accessed within the Android container.

Similar code exists for the `anbox_bridge` and `anbox_audio` socket:

https://github.com/anbox/anbox/blob/3ed2e6d5c360d57b6aa61386e279adf3ff155ded/src/anbox/container/service.cpp#L54-L55

https://github.com/anbox/anbox/blob/3ed2e6d5c360d57b6aa61386e279adf3ff155ded/src/anbox/audio/server.cpp#L59-L61

Fixes #603.

Cc: @necessarily-equal 