### PR TITLE
Added missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ system:
  * libsdl2
  * libprotobuf
  * protobuf-compiler
+ * python2
  * lxc (>= 3.0)
 
 On an Ubuntu system you can install all build dependencies with the following
@@ -92,7 +93,7 @@ $ sudo apt install build-essential cmake cmake-data debhelper dbus google-mock \
     libboost-thread-dev libcap-dev libsystemd-dev libegl1-mesa-dev \
     libgles2-mesa-dev libglm-dev libgtest-dev liblxc1 \
     libproperties-cpp-dev libprotobuf-dev libsdl2-dev libsdl2-image-dev lxc-dev \
-    pkg-config protobuf-compiler 
+    pkg-config protobuf-compiler python2
 ```
 We recommend Ubuntu 18.04 (bionic) with **GCC 7.x** as your build environment.
 


### PR DESCRIPTION
Added python2 as build dependency. On modern system it no longer is preinstalled by default.