### PR TITLE
platform/sdl: fixup window double-closed in SDL_WINDOWEVENT_CLOSE

### DIFF
--- a/src/anbox/platform/sdl/window.cpp
+++ b/src/anbox/platform/sdl/window.cpp
@@ -202,9 +202,6 @@ void Window::process_event(const SDL_Event &event) {
     case SDL_WINDOWEVENT_HIDDEN:
       break;
     case SDL_WINDOWEVENT_CLOSE:
-      if (observer_)
-        observer_->window_deleted(id_);
-
       close();
       break;
     default:


### PR DESCRIPTION
When user close window by DE's dock or keyboard shortcut (for example, ALT-F4). The window will be closed twice.
And session-manager will print a warning like:
```
Got window removed event for unknown window (id 0)
```
The `close()` do the same things as `if (observer_) observer_->window_deleted(id_);`
This patch will fixup this.