### PR TITLE
session-manager: implement configurable server-side decoration

### DIFF
--- a/scripts/snap-wrapper.sh
+++ b/scripts/snap-wrapper.sh
@@ -47,6 +47,10 @@ if [ "$(snapctl get touch-emulation.enable)" = false ]; then
 	export ANBOX_ENABLE_TOUCH_EMULATION=false
 fi
 
+if [ "$(snapctl get server-side-decoration.enable)" = true ]; then
+	export ANBOX_FORCE_SERVER_SIDE_DECORATION=true
+fi
+
 # Use custom Anbox binary for debugging purposes if available
 ANBOX="$SNAP"/usr/bin/anbox
 if [ -e "$SNAP_COMMON"/anbox.debug ]; then

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -51,6 +51,7 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   bool use_system_dbus_ = false;
   bool use_software_rendering_ = false;
   bool no_touch_emulation_ = false;
+  bool server_side_decoration_ = false;
 };
 }  // namespace cmds
 }  // namespace anbox

--- a/src/anbox/platform/base_platform.h
+++ b/src/anbox/platform/base_platform.h
@@ -64,6 +64,7 @@ struct Configuration {
   graphics::Rect display_frame = graphics::Rect::Invalid;
   bool single_window = false;
   bool no_touch_emulation = false;
+  bool server_side_decoration = false;
 };
 
 std::shared_ptr<BasePlatform> create(const std::string &name,

--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -418,7 +418,8 @@ std::shared_ptr<wm::Window> Platform::create_window(
   }
 
   auto id = next_window_id();
-  auto w = std::make_shared<Window>(renderer_, id, task, shared_from_this(), frame, title, !window_size_immutable_);
+  auto w = std::make_shared<Window>(renderer_, id, task, shared_from_this(), frame, title,
+		  !window_size_immutable_, !config_.server_side_decoration);
   focused_sdl_window_id_ = w->window_id();
   windows_.insert({id, w});
   return w;

--- a/src/anbox/platform/sdl/window.h
+++ b/src/anbox/platform/sdl/window.h
@@ -52,7 +52,8 @@ class Window : public std::enable_shared_from_this<Window>, public wm::Window {
          const std::shared_ptr<Observer> &observer,
          const graphics::Rect &frame,
          const std::string &title,
-         bool resizable);
+         bool resizable,
+         bool borderless);
   ~Window();
 
   void process_event(const SDL_Event &event);


### PR DESCRIPTION
Add command line option `--server-side-decoration` and `ANBOX_FORCE_SERVER_SIDE_DECORATION` env-var for session-manager to use server-side decoration. Both methods can activate it.

When using server-side decoration, the hit test handler will NOT be set beacuse we don't need to simulate the behavior of the title bar and resize area.

Currently android framework layer will render caption (client-side decoration), in order to let the android framework layer know that sometimes we need server-side decoration. I introduce a special system property `ro.anbox.no_decorations`. When it is true, hide the android client-side decoration caption unconditionally. When server-side decoration is enabled, this property is set to `1`.

Therefore, server-side decoratio needs to be used with another pull request to anbox's android framework, otherwise you will get two title bars. https://github.com/anbox/platform_frameworks_base/pull/6

Fix #1308 