### PR TITLE
fix script path in doc/build-android.md

### DIFF
--- a/docs/build-android.md
+++ b/docs/build-android.md
@@ -63,7 +63,7 @@ Once the build is done we need to take the results and create an image file
 suitable for Anbox.
 
 ```
-$ cd $HOME/anbox-work/anbox
+$ cd $HOME/anbox-work/vendor/anbox
 $ scripts/create-package.sh \
     $PWD/../out/target/product/x86_64/ramdisk.img \
     $PWD/../out/target/product/x86_64/system.img


### PR DESCRIPTION
If I'm not mistaken, the path was incorrect. The anbox dir is apparently in /vendor.