### PR TITLE
create-package.sh: add optional third argument for output

### DIFF
--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -4,9 +4,10 @@ set -ex
 
 ramdisk=$1
 system=$2
+image=${3:-android.img}
 
 if [ -z "$ramdisk" ] || [ -z "$system" ]; then
-	echo "Usage: $0 <ramdisk> <system image>"
+	echo "Usage: $0 <ramdisk> <system image> [<output anbox image>]"
 	exit 1
 fi
 
@@ -29,7 +30,7 @@ sudo $workdir/uidmapshift -b $rootfs 0 100000 65536
 # FIXME
 sudo chmod +x $rootfs/anbox-init.sh
 
-sudo mksquashfs $rootfs android.img -comp xz -no-xattrs
-sudo chown $USER:$USER android.img
+sudo mksquashfs $rootfs $image -comp xz -no-xattrs
+sudo chown $USER:$USER $image
 
 sudo rm -rf $workdir


### PR DESCRIPTION
This change allows having a source dir that is readonly. For example calling the script as such: `scripts/create-package.sh ../../out/target/product/$ARCH/ramdisk.img ../../out/target/product/$ARCH/system.img ../../out/android.img`.

One often wants to use a read only source dir when building from a container or in pmOS' case, from a chroot.

This change is backward compatible.