### PR TITLE
container-manager: support setting --force-squashfuse

### DIFF
--- a/src/anbox/cmds/container_manager.h
+++ b/src/anbox/cmds/container_manager.h
@@ -45,6 +45,7 @@ class ContainerManager : public cli::CommandWithFlagsAndAction {
   bool privileged_ = false;
   bool daemon_ = false;
   bool enable_rootfs_overlay_ = false;
+  bool enable_squashfuse_ = false;
   std::string container_network_address_;
   std::string container_network_gateway_;
   std::string container_network_dns_servers_;


### PR DESCRIPTION
`anbox container-manager --force-squashfuse` enforces to use `squashfuse`.

This flag is useful for avoiding `anbox[70]: Could not create loopback device: No such file or directory` error that happens when running Anbox inside Docker : https://github.com/aind-containers/aind/issues/5