### PR TITLE
WIP: scripts: make image creation time and modification times reproducibles

### DIFF
--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -30,7 +30,13 @@ sudo $workdir/uidmapshift -b $rootfs 0 100000 65536
 # FIXME
 sudo chmod +x $rootfs/anbox-init.sh
 
-sudo mksquashfs $rootfs $image -comp xz -no-xattrs
+reproducible_args=""
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+	reproducible_args="-fstime $SOURCE_DATE_EPOCH"
+	find $rootfs -newermt "@$SOURCE_DATE_EPOCH" -print0 |
+		xargs -0r touch --no-dereference --date="@$SOURCE_DATE_EPOCH"
+fi
+sudo mksquashfs $rootfs $image -comp xz -no-xattrs $reproducible_args
 sudo chown $USER:$USER $image
 
 sudo rm -rf $workdir


### PR DESCRIPTION
see
https://reproducible-builds.org/docs/source-date-epoch/
and
https://reproducible-builds.org/docs/archives/

There are built-in features in mksquashfs 4.4 to do just that,
but this allows using the previous version which is still widespread
(Ubuntu ships it starting with 19.10, so there are no LTS with 4.4)

This has been tested to work with Ubuntu 16.04 LTS.