### PR TITLE
typo: command help

### DIFF
--- a/src/anbox/cli.cpp
+++ b/src/anbox/cli.cpp
@@ -236,8 +236,8 @@ void cli::CommandWithFlagsAndAction::help(std::ostream& out) {
 }
 
 cli::cmd::Help::Help(Command& cmd)
-    : Command{cli::Name{"help"}, cli::Usage{"prints a short help message"},
-              cli::Description{"prints a short help message"}},
+    : Command{cli::Name{"help"}, cli::Usage{"Print a short help message"},
+              cli::Description{"Print a short help message"}},
       command{cmd} {}
 
 // From Command


### PR DESCRIPTION
This uniforms message of subcommand help to others description.

```
$ ./anbox help
NAME:
    anbox - anbox

USAGE:
    anbox [command options] [arguments...]

COMMANDS:
    wait-ready                     Wait until the Android system has successfully booted                                               
    help                           Print a short help message                                                                          
    session-manager                Run the the anbox session manager                                                                   
    launch                         Launch an Activity by sending an intent                                                             
    check-features                 Check that the host system supports all necessary features                                          
    system-info                    Print various information about the system we're running on                                         
    version                        print the version of the daemon
```

Signed-off-by: keyangxie <keyang.xie@gmail.com>