### PR TITLE
apt install python2 is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ sudo apt install build-essential cmake cmake-data debhelper dbus google-mock \
     libboost-thread-dev libcap-dev libsystemd-dev libegl1-mesa-dev \
     libgles2-mesa-dev libglm-dev libgtest-dev liblxc1 \
     libproperties-cpp-dev libprotobuf-dev libsdl2-dev libsdl2-image-dev lxc-dev \
-    pkg-config protobuf-compiler python2
+    pkg-config protobuf-compiler python-minimal
 ```
 We recommend Ubuntu 18.04 (bionic) with **GCC 7.x** as your build environment.
 


### PR DESCRIPTION
`apt install python-minimal` will setup python 2.7