### PR TITLE
armv7 tweaks

### DIFF
--- a/products/armv7-a-neon/BoardConfig.mk
+++ b/products/armv7-a-neon/BoardConfig.mk
@@ -13,6 +13,8 @@ TARGET_CPU_VARIANT := generic
 TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
 
+TARGET_USES_64_BIT_BINDER := true
+
 SMALLER_FONT_FOOTPRINT := true
 MINIMAL_FONT_FOOTPRINT := true
 # Some framework code requires this to enable BT

--- a/products/armv7-a-neon/BoardConfig.mk
+++ b/products/armv7-a-neon/BoardConfig.mk
@@ -30,6 +30,12 @@ USE_OPENGL_RENDERER := true
 
 BOARD_USE_LEGACY_UI := true
 
+# Enable dex-preoptimization to speed up the first boot sequence
+# of an SDK AVD. Note that this operation only works on Linux for now
+ifeq ($(HOST_OS),linux)
+WITH_DEXPREOPT ?= true
+endif
+
 TARGET_USERIMAGES_USE_EXT4 := true
 BOARD_SYSTEMIMAGE_PARTITION_SIZE := 2147483648 # 2 GB
 BOARD_USERDATAIMAGE_PARTITION_SIZE := 576716800


### PR DESCRIPTION
This backport two fixes by @Minecrell used in the postmarketOS Anbox image for armv7.

The first make the Anbox image work on recent kernels, as 32bits binder support was dropped. The second is for consistency.