### PR TITLE
cmake/FindGMock: fixup b2accb4aa

### DIFF
--- a/cmake/FindGMock.cmake
+++ b/cmake/FindGMock.cmake
@@ -89,7 +89,6 @@ if (NOT (GTEST_FOUND AND GTEST_MAIN_FOUND AND GMOCK_FOUND AND GMOCK_MAIN_FOUND))
     set(GTEST_LIBRARIES gtest)
     set(GTEST_MAIN_LIBRARIES gtest_main)
     set(GMOCK_LIBRARIES gmock gmock_main)
-    set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
 
     unset(findgmock_cxx_flags)
     unset(findgmock_bin_dir)
@@ -99,3 +98,5 @@ if (NOT (GTEST_FOUND AND GTEST_MAIN_FOUND AND GMOCK_FOUND AND GMOCK_MAIN_FOUND))
     unset(findgmock_gmock_main_lib)
 
 endif()
+
+set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})


### PR DESCRIPTION
A few files, notably the testsuite, use the GTEST_BOTH_LIBRARIES. This
sets it on both code path and correct the mistake from earlier (#1423).

The Alpine package check caught it.