### PR TITLE
make help message fully consistent

### DIFF
--- a/src/anbox/cmds/version.cpp
+++ b/src/anbox/cmds/version.cpp
@@ -24,7 +24,7 @@
 anbox::cmds::Version::Version()
     : CommandWithFlagsAndAction{
           cli::Name{"version"}, cli::Usage{"version"},
-          cli::Description{"print the version of the daemon"}} {
+          cli::Description{"Print the version of the daemon"}} {
   action([](const cli::Command::Context& ctxt) {
     ctxt.cout << "anbox " << build::version << std::endl;
     return 0;


### PR DESCRIPTION
Follow up to https://github.com/anbox/anbox/pull/1442.

the first word of the `anbox version` description ("print the version of the daemon") had no capital, unlike the other help messages. This merge request fixes that. 