### PR TITLE
snap: fail to build if image's checksums are wrong

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,7 @@ parts:
         wget http://build.anbox.io/android-images/$IMAGE_PATH/$IMAGE_NAME
 
         echo "$IMAGE_HASH $IMAGE_NAME" > image-hash
-        sha256sum -c image-hash
+        sha256sum -c image-hash || exit 1
 
         mv $IMAGE_NAME $SNAPCRAFT_PART_INSTALL/android.img
 


### PR DESCRIPTION
if the image isn't the right one, the build should *not* continue.

I tested that part of the script, so it should not break build.