### PR TITLE
message_processor.cpp: fix underflow error

### DIFF
--- a/src/anbox/rpc/message_processor.cpp
+++ b/src/anbox/rpc/message_processor.cpp
@@ -54,7 +54,7 @@ bool MessageProcessor::process_data(const std::vector<std::uint8_t> &data) {
 
     // If we don't have yet all bytes for a new message return and wait
     // until we have all.
-    if (buffer_.size() - header_size < message_size) break;
+    if (buffer_.size() < (message_size + header_size)) break;
 
     if (message_type == MessageType::invocation) {
       anbox::protobuf::rpc::Invocation raw_invocation;


### PR DESCRIPTION
fixes a error where the message
```
[platform_message_processor.cpp:46@process_event_sequence] Failed to parse events from raw string
```
is followed by a crash at `../src/anbox/rpc/message_processor.cpp:81`.

since buffer_.size() is signed, it could underflow and the safety would
not trigger, leading to a crash.

credits to mntmn for finding the bug and the solution.