### PR TITLE
rpc: use ByteSizeLong from protobuf

### DIFF
--- a/src/anbox/rpc/channel.cpp
+++ b/src/anbox/rpc/channel.cpp
@@ -43,7 +43,7 @@ void Channel::call_method(std::string const &method_name,
 }
 
 void Channel::send_event(google::protobuf::MessageLite const &event) {
-  VariableLengthArray<2048> buffer{static_cast<size_t>(event.ByteSize())};
+  VariableLengthArray<2048> buffer{event.ByteSizeLong()};
   event.SerializeWithCachedSizesToArray(buffer.data());
 
   anbox::protobuf::rpc::Result response;
@@ -55,8 +55,7 @@ void Channel::send_event(google::protobuf::MessageLite const &event) {
 protobuf::rpc::Invocation Channel::invocation_for(
     std::string const &method_name,
     google::protobuf::MessageLite const *request) {
-  anbox::VariableLengthArray<2048> buffer{
-      static_cast<size_t>(request->ByteSize())};
+  anbox::VariableLengthArray<2048> buffer{request->ByteSizeLong()};
 
   request->SerializeWithCachedSizesToArray(buffer.data());
 
@@ -72,7 +71,7 @@ protobuf::rpc::Invocation Channel::invocation_for(
 
 void Channel::send_message(const std::uint8_t &type,
                            google::protobuf::MessageLite const &message) {
-  const size_t size = message.ByteSize();
+  const size_t size = message.ByteSizeLong();
   const unsigned char header_bytes[header_size] = {
       static_cast<unsigned char>((size >>16) & 0xff),
       static_cast<unsigned char>((size >> 8) & 0xff),

--- a/src/anbox/rpc/message_processor.cpp
+++ b/src/anbox/rpc/message_processor.cpp
@@ -87,7 +87,7 @@ bool MessageProcessor::process_data(const std::vector<std::uint8_t> &data) {
 void MessageProcessor::send_response(::google::protobuf::uint32 id,
                                      google::protobuf::MessageLite *response) {
   VariableLengthArray<serialization_buffer_size> send_response_buffer(
-      static_cast<size_t>(response->ByteSize()));
+      response->ByteSizeLong());
 
   response->SerializeWithCachedSizesToArray(send_response_buffer.data());
 
@@ -96,7 +96,7 @@ void MessageProcessor::send_response(::google::protobuf::uint32 id,
   send_response_result.set_response(send_response_buffer.data(),
                                     send_response_buffer.size());
 
-  send_response_buffer.resize(send_response_result.ByteSize());
+  send_response_buffer.resize(send_response_result.ByteSizeLong());
   send_response_result.SerializeWithCachedSizesToArray(
       send_response_buffer.data());
 


### PR DESCRIPTION
ByteSize() is deperecated, and BiteSizeLong() returns a size_t already,
which is what we use. This way, we also avoid potential overflows when
casting to int back and from.