### PR TITLE
forbid android from waking up the host

### DIFF
--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -346,6 +346,9 @@ void LxcContainer::start(const Configuration &configuration) {
 
   set_config_item(lxc_config_init_cmd_key, "/anbox-init.sh");
 
+  // forbid android from waking up the system (https://github.com/anbox/anbox/issues/1436)
+  set_config_item("lxc.cap.drop", "wake_alarm");
+
 #ifdef ENABLE_SNAP_CONFINEMENT
   // If we're running inside the snap environment snap-confine already created a
   // cgroup for us we need to use as otherwise presevering a namespace wont help.


### PR DESCRIPTION
closes https://github.com/anbox/anbox/issues/1436. It could not be the perfect solution, but I don't think it has potential for regressions.

`lxc.cap.drop` existed already in LXC1.0, so I assume this should be
backward compatible.