### PR TITLE
Update docs for unable to access '/ dev / binder'

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -66,6 +66,11 @@ Now you should have two new nodes in your systems `/dev` directory:
  /dev/binder
 ```
 
+> In Ubuntu 19.10 the binder driver doesn't create /dev/binder when loaded. That is intentional. 
+> Instead it provides support for binderfs (see https://brauner.github.io/2019/01/09/android-binderfs.html) 
+> which is instead since PR anbox/anbox#1309
+
+
 ## Install the Anbox snap
 
 Installing the Anbox snap is very simple:


### PR DESCRIPTION
wording taken from https://github.com/anbox/anbox-modules/issues/20#issuecomment-570204411 @morphis comment
ref #20 #1309 #1240