### PR TITLE
swiftshader disable warnings as errors

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -207,6 +207,8 @@ parts:
     # Last upstream version which doesn't make use of newer cmake features we can't
     # support on 16.04
     source-commit: 1f456938b36f02404830c2e831e328d8ba8d30cd
+    cmake-parameters:
+      - -DSWIFTSHADER_WARNINGS_AS_ERRORS=FALSE
     override-build: |
       git submodule update --init
       snapcraftctl build


### PR DESCRIPTION
this should fix the snap build error, I can't test this but should work, this should disable warnings treated like error on swiftshader build.