### PR TITLE
20.04 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   separate the Android system fully from the host.
 confinement: devmode
 grade: devel
-base: core18
+base: core20
 architectures: [amd64]
 adopt-info: anbox
 
@@ -24,7 +24,7 @@ plugs:
 
 apps:
   anbox:
-    command: desktop-launch $SNAP/bin/anbox-wrapper.sh
+    command: bin/desktop-launch $SNAP/bin/anbox-wrapper.sh
     slots:
       - dbus-session-slot
     plugs:
@@ -53,7 +53,7 @@ apps:
   shell:
     command: bin/anbox-shell.sh
   android-settings:
-    command: desktop-launch $SNAP/bin/app-android-settings.sh
+    command: bin/desktop-launch $SNAP/bin/app-android-settings.sh
     desktop: desktop/android-settings.desktop
     slots:
       - dbus-session-slot
@@ -70,7 +70,7 @@ apps:
       - desktop
 
   appmgr:
-    command: desktop-launch $SNAP/bin/app-appmgr.sh
+    command: bin/desktop-launch $SNAP/bin/app-appmgr.sh
     desktop: desktop/appmgr.desktop
     slots:
       - dbus-session-slot
@@ -166,7 +166,7 @@ parts:
       - libseccomp-dev
       - pkg-config
     plugin: autotools
-    configflags:
+    autotools-configure-parameters:
       - --disable-selinux
       - --disable-python
       - --disable-lua
@@ -181,6 +181,7 @@ parts:
       - --enable-capabilities
       - --with-rootfs-path=/var/snap/anbox/common/lxc/
       - --libexecdir=/snap/anbox/current/libexec/
+      - --prefix=/usr/
     override-build: |
       set -ex
       git config user.email "buildbot@anbox.io"
@@ -194,15 +195,15 @@ parts:
     organize:
       snap/anbox/current/libexec: libexec
     prime:
-      - lib/liblxc.so.1
-      - lib/liblxc.so.1.4.0
+      - usr/lib/liblxc.so.1
+      - usr/lib/liblxc.so.1.4.0
       - libexec/lxc/lxc-monitord
-      - bin/lxc-start
-      - bin/lxc-stop
-      - bin/lxc-info
-      - bin/lxc-attach
-      - bin/lxc-ls
-      - bin/lxc-top
+      - usr/bin/lxc-start
+      - usr/bin/lxc-stop
+      - usr/bin/lxc-info
+      - usr/bin/lxc-attach
+      - usr/bin/lxc-ls
+      - usr/bin/lxc-top
 
   swiftshader:
     plugin: cmake
@@ -251,7 +252,7 @@ parts:
       - desktop-glib-only
     source: .
     source-type: git
-    configflags:
+    cmake-parameters:
       # FIXME: Anbox currently has some paths with hard coded prefixes. Once
       # that is fixed we can avoid using a prefix here.
       - -DCMAKE_INSTALL_PREFIX:PATH=/usr
@@ -265,13 +266,13 @@ parts:
       - cmake
       - cmake-data
       - cmake-extras
-      - debhelper
       - dbus
+      - debhelper
       - google-mock
       - libboost-dev
       - libboost-filesystem-dev
-      - libboost-log-dev
       - libboost-iostreams-dev
+      - libboost-log-dev
       - libboost-program-options-dev
       - libboost-system-dev
       - libboost-test-dev
@@ -281,26 +282,29 @@ parts:
       - libegl1-mesa-dev
       - libgles2-mesa-dev
       - libglm-dev
+      - libgmock-dev
       - libgtest-dev
-      - libprotobuf-dev
       - libproperties-cpp-dev
+      - libprotobuf-dev
       - libsdl2-dev
       - libsdl2-image-dev
       - libsystemd-dev
+      - libx11-xcb-dev
       - pkg-config
       - protobuf-compiler
+      - python2
     stage-packages:
-      - libboost-filesystem1.65.1
-      - libboost-iostreams1.65.1
-      - libboost-log1.65.1
-      - libboost-program-options1.65.1
-      - libboost-system1.65.1
-      - libboost-thread1.65.1
+      - libboost-filesystem1.71.0
+      - libboost-iostreams1.71.0
+      - libboost-log1.71.0
+      - libboost-program-options1.71.0
+      - libboost-system1.71.0
+      - libboost-thread1.71.0
       - libdb5.3
       - libegl1-mesa
       - libgl1-mesa-glx
       - libgles2-mesa
-      - libprotobuf-lite10
+      - libprotobuf-lite17
       - libsdl2-2.0-0
       - libsdl2-gfx-1.0-0
       - libsdl2-image-2.0-0
@@ -313,4 +317,7 @@ parts:
       snapcraftctl set-grade stable
       rev=$(cd "$SNAPCRAFT_PART_SRC_WORK" ; git rev-parse --short HEAD)
       snapcraftctl set-version 4+gitr"$rev"
+      # HACK: for some reason, snapcraft puts a copy of the source code
+      # in the build directory. Let's remove it so it doesn't conflict.
+      rm -rf *
       snapcraftctl build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -209,9 +209,7 @@ parts:
     plugin: cmake
     source: https://swiftshader.googlesource.com/SwiftShader
     source-type: git
-    # Last upstream version which doesn't make use of newer cmake features we can't
-    # support on 18.04
-    source-commit: 1f456938b36f02404830c2e831e328d8ba8d30cd
+    source-commit: b6e8c3f0f4830887d69ba765a922ac3c40e81dd9
     organize:
       libEGL.so: lib/anbox/swiftshader/libEGL.so
       libGLES_CM.so: lib/anbox/swiftshader/libGLES_CM.so


### PR DESCRIPTION
This upgrades the snap to the 20.04 version. @tomasz-grobelny figured out the second part, cheers!

@morphis: before merging this, maybe we could fix some inconsistency. The `snapcraft.yaml` contains `grade: devel`, but also contains the `snapcraftctl set-grade stable` command. Which should we keep?