### PR TITLE
snap: cleanup devel/stable ambiguity

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -312,7 +312,6 @@ parts:
       - usr/share/anbox
       - usr/lib/*-linux-*/
     override-build: |
-      snapcraftctl set-grade stable
       rev=$(cd "$SNAPCRAFT_PART_SRC_WORK" ; git rev-parse --short HEAD)
       snapcraftctl set-version 4+gitr"$rev"
       # HACK: for some reason, snapcraft puts a copy of the source code


### PR DESCRIPTION
the snap contains `grade: devel` at the top already