### PR TITLE
Use current system user and group in docker build script

### DIFF
--- a/scripts/build-with-docker.sh
+++ b/scripts/build-with-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 docker build -t anbox/anbox-builder .
-docker run --rm -v $PWD:/anbox anbox/anbox-builder /anbox/scripts/clean-build.sh
+docker run --rm --user=$(id -u):$(id -g) --volume=$PWD:/anbox anbox/anbox-builder /anbox/scripts/clean-build.sh


### PR DESCRIPTION
When compiling in a container the system user root is owning all of the produced artifacts.
Moving and removing build artifacts was not possible without elevation.

The script was modified to use the current system user and group id instead.

