### PR TITLE
add libexpat1-dev to snap build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -288,6 +288,7 @@ parts:
       - libsdl2-image-dev
       - libsystemd-dev
       - libx11-xcb-dev
+      - libexpat1-dev
       - pkg-config
       - protobuf-compiler
       - python2


### PR DESCRIPTION
A full snap build fails with the following error:

```
    Could NOT find EXPAT (missing: EXPAT_LIBRARY EXPAT_INCLUDE_DIR)
...
make[2]: *** [external/CMakeFiles/sdbus-cpp.dir/build.make:107: external/sdbus-cpp/src/sdbus-cpp-stamp/sdbus-cpp-configure] Error 1
```

According to the output `sdbus-cpp` is missing a dependency. I suspect it happened with https://github.com/anbox/anbox/commit/e29ee87bb15d71f176ba48a6638d703917051975.

I changed the snapcraft.yaml to include `libexpat1-dev` as it is declared in the Dockerfile. The build works again.