### PR TITLE
snap: drop lxc fork

### DIFF
--- a/scripts/container-manager.sh
+++ b/scripts/container-manager.sh
@@ -45,8 +45,8 @@ start() {
 	# Ensure FUSE support for user namespaces is enabled
 	echo Y | tee /sys/module/fuse/parameters/userns_mounts || echo "WARNING: kernel doesn't support fuse in user namespaces"
 
-	# liblxc.so.1 is in $SNAP/lib
-	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/liblxc"
+	# liblxc.so.1 is in $SNAP/usr/lib/$ARCH-linux-gnu
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH-linux-gnu"
 
 	# For unknown reason we got bug reports that the container manager failed to start
 	# because it cannot find libboost_log.so.1.58.0 To mitigate this we're adding the

--- a/scripts/snap-wrapper.sh
+++ b/scripts/snap-wrapper.sh
@@ -13,10 +13,10 @@ fi
 # where it can be found
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/pulseaudio"
 
-# liblxc.so.1 is in $SNAP/usr/lib
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib"
 
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH"
+# liblxc.so.1 is in /usr/lib/$ARCH-linux-gnu/
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH-linux-gnu/"
 
 # We set XDG_DATA_HOME to SNAP_USER_COMMON here as this will be the location we will
 # create all our application launchers in. The system application launcher will

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -155,56 +155,6 @@ parts:
     prime:
       - usr/bin/zip
 
-  lxc:
-    source: https://github.com/lxc/lxc
-    source-type: git
-    source-tag: lxc-3.0.1
-    build-packages:
-      - libapparmor-dev
-      - libcap-dev
-      - libgnutls28-dev
-      - libseccomp-dev
-      - pkg-config
-    plugin: autotools
-    autotools-configure-parameters:
-      - --disable-selinux
-      - --disable-python
-      - --disable-lua
-      - --disable-tests
-      - --disable-examples
-      - --disable-doc
-      - --disable-api-docs
-      - --disable-bash
-      - --disable-cgmanager
-      - --enable-apparmor
-      - --enable-seccomp
-      - --enable-capabilities
-      - --with-rootfs-path=/var/snap/anbox/common/lxc/
-      - --libexecdir=/snap/anbox/current/libexec/
-      - --prefix=/usr/
-    override-build: |
-      set -ex
-      git config user.email "buildbot@anbox.io"
-      git config user.name "Anbox Buildbot"
-      git remote add anbox https://github.com/anbox/lxc
-      git fetch anbox
-      # apparmor: don't require a transition for Anbox child profiles
-      git cherry-pick 2f81fb7c91560b32e506bb874f8cd63e37985906
-      set +ex
-      snapcraftctl build
-    organize:
-      snap/anbox/current/libexec: libexec
-    prime:
-      - usr/lib/liblxc.so.1
-      - usr/lib/liblxc.so.1.4.0
-      - libexec/lxc/lxc-monitord
-      - usr/bin/lxc-start
-      - usr/bin/lxc-stop
-      - usr/bin/lxc-info
-      - usr/bin/lxc-attach
-      - usr/bin/lxc-ls
-      - usr/bin/lxc-top
-
   swiftshader:
     plugin: cmake
     source: https://swiftshader.googlesource.com/SwiftShader
@@ -246,7 +196,6 @@ parts:
   anbox:
     plugin: cmake
     after:
-      - lxc
       - desktop-glib-only
     source: .
     source-type: git
@@ -266,6 +215,7 @@ parts:
       - cmake-extras
       - dbus
       - debhelper
+      - libexpat1-dev
       - google-mock
       - libboost-dev
       - libboost-filesystem-dev
@@ -282,6 +232,7 @@ parts:
       - libglm-dev
       - libgmock-dev
       - libgtest-dev
+      - liblxc-dev
       - libproperties-cpp-dev
       - libprotobuf-dev
       - libsdl2-dev
@@ -302,6 +253,7 @@ parts:
       - libegl1-mesa
       - libgl1-mesa-glx
       - libgles2-mesa
+      - liblxc1
       - libprotobuf-lite17
       - libsdl2-2.0-0
       - libsdl2-gfx-1.0-0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -254,6 +254,7 @@ parts:
       - libgl1-mesa-glx
       - libgles2-mesa
       - liblxc1
+      - lxc
       - libprotobuf-lite17
       - libsdl2-2.0-0
       - libsdl2-gfx-1.0-0


### PR DESCRIPTION
The LXC fork that is used by the snap package hasn't been updated for some years and is currently not being used anyway (Snap will try to use the host system's liblxc.so.1!) This PR attemps to make Anbox work with Ubuntu's LXC package for the snap.

However, it doesn't work yet as it fails with this error in `container.log`:

```
lxc 20200908144116.511 INFO     start - start.c:do_start:1211 - Unshared CLONE_NEWCGROUP
lxc 20200908144116.511 TRACE    conf - conf.c:remount_all_slave:3094 - Remounted all mount table entries as MS_SLAVE
lxc 20200908144116.511 ERROR    conf - conf.c:lxc_mount_rootfs:1242 - No such file or directory - Failed to access to "/usr/lib/x86_64-linux-gnu/lxc". Check it is present
lxc 20200908144116.511 ERROR    conf - conf.c:lxc_setup_rootfs_prepare_root:3178 - Failed to setup rootfs for
lxc 20200908144116.511 ERROR    conf - conf.c:lxc_setup:3277 - Failed to setup rootfs
lxc 20200908144116.511 ERROR    start - start.c:do_start:1231 - Failed to setup container "default"
lxc 20200908144116.511 ERROR    sync - sync.c:__sync_wait:40 - An error occurred in another process (expected sequence number 5)
lxc 20200908144116.511 DEBUG    network - network.c:lxc_delete_network:3693 - Deleted network devices
lxc 20200908144116.511 TRACE    start - start.c:lxc_serve_state_socket_pair:491 - Sent container state "ABORTING" to 13
lxc 20200908144116.511 TRACE    start - start.c:lxc_serve_state_clients:427 - Set container state to ABORTING
```

Any idea?