### PR TITLE
README: Fix image paths after /anbox -> /vendor/anbox change

### DIFF
--- a/docs/build-android.md
+++ b/docs/build-android.md
@@ -65,9 +65,11 @@ suitable for Anbox.
 ```
 $ cd $HOME/anbox-work/vendor/anbox
 $ scripts/create-package.sh \
-    $PWD/../out/target/product/x86_64/ramdisk.img \
-    $PWD/../out/target/product/x86_64/system.img
+    $PWD/../../out/target/product/x86_64/ramdisk.img \
+    $PWD/../../out/target/product/x86_64/system.img
 ```
+
+(replace `x86_64` with your target architecture)
 
 This will create an *android.img* file in the current directory.
 


### PR DESCRIPTION
Also, add a hint that the path will be slightly different for each target architecture.