### PR TITLE
Use proto2 syntax

### DIFF
--- a/src/anbox/protobuf/anbox_bridge.proto
+++ b/src/anbox/protobuf/anbox_bridge.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 package anbox.protobuf.bridge;

--- a/src/anbox/protobuf/anbox_container.proto
+++ b/src/anbox/protobuf/anbox_container.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 package anbox.protobuf.container;

--- a/src/anbox/protobuf/anbox_rpc.proto
+++ b/src/anbox/protobuf/anbox_rpc.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 package anbox.protobuf.rpc;


### PR DESCRIPTION
Added version hints to protobuf files, so libprotobuf stops complaining:


```
[libprotobuf WARNING google/protobuf/compiler/parser.cc:562] No syntax specified for the proto file: anbox_container.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)

[libprotobuf WARNING google/protobuf/compiler/parser.cc:562] No syntax specified for the proto file: anbox_bridge.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)

[libprotobuf WARNING google/protobuf/compiler/parser.cc:562] No syntax specified for the proto file: anbox_rpc.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```