### PR TITLE
session-manager --window-size is ignored

### DIFF
--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -174,12 +174,17 @@ anbox::cmds::SessionManager::SessionManager()
         std::size_t indexOfComma = window_size_string.find(',');
         
         if (indexOfComma > 0) {
-          int w = std::stoi(window_size_string.substr(0, window_size_string.length() - indexOfComma));
-          int h = std::stoi(window_size_string.substr(indexOfComma + 1));
-          display_frame = graphics::Rect(w, h);
+          try {
+            int w = std::stoi(window_size_string.substr(0, window_size_string.length() - indexOfComma));
+            int h = std::stoi(window_size_string.substr(indexOfComma + 1));
+            display_frame = graphics::Rect(w, h);
+          } 
+          catch (std::exception &err) {
+            WARNING("malformed window-size. expected: --window-size=[width],[height}");
+          }
         }
       }
-
+      
       DEBUG("using window size: " + std::to_string(display_frame.width()) + "," + std::to_string(display_frame.height()));
     }
 

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -46,7 +46,7 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   std::string desktop_file_hint_;
   std::string disabled_sensors_;
   bool single_window_ = false;
-  graphics::Rect window_size_;
+  std::string window_size_string;
   bool standalone_ = false;
   bool experimental_ = false;
   bool use_system_dbus_ = false;


### PR DESCRIPTION
The passed value is ignored and is always the default.

Presumably an issue with argument instantiation. I suppose the current cli flag implementation cannot handle complex objects like `graphics::Rect`.

* convert argument `window-size` to string
* parse `window-size=[width],[height]` argument when called with `--single-window`
  * give format hints when exceptions occur
