### PR TITLE
Refactor namespaces declarations

### DIFF
--- a/src/anbox/android/intent.cpp
+++ b/src/anbox/android/intent.cpp
@@ -19,8 +19,7 @@
 
 #include <ostream>
 
-namespace anbox {
-namespace android {
+namespace anbox::android {
 bool Intent::valid() const {
   // At the moment we only support component+package for intents
   // (see android/service/android_api_skeleton.cpp for more details)
@@ -49,5 +48,4 @@ std::ostream &operator<<(std::ostream &out, const Intent &intent) {
   out << "]";
   return out;
 }
-}  // namespace android
-}  // namespace anbox
+}

--- a/src/anbox/android/intent.h
+++ b/src/anbox/android/intent.h
@@ -21,8 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace anbox {
-namespace android {
+namespace anbox::android {
 struct Intent {
   std::string action;
   std::string uri;
@@ -36,7 +35,5 @@ struct Intent {
 };
 
 std::ostream &operator<<(std::ostream &out, const Intent &intent);
-}  // namespace android
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/android/ip_config_builder.cpp
+++ b/src/anbox/android/ip_config_builder.cpp
@@ -52,8 +52,7 @@ std::string assignment_to_string(const aa::IpConfigBuilder::Assignment &value) {
 }
 }
 
-namespace anbox {
-namespace android {
+namespace anbox::android {
 std::size_t IpConfigBuilder::write(common::BinaryWriter &writer) {
   writer.set_byte_order(common::BinaryWriter::Order::Big);
 
@@ -110,5 +109,4 @@ void IpConfigBuilder::set_dns_servers(const std::vector<std::string> &dns_server
 void IpConfigBuilder::set_id(uint32_t id) {
   id_ = id;
 }
-}  // namespace android
-}  // namespace anbox
+}

--- a/src/anbox/android/ip_config_builder.h
+++ b/src/anbox/android/ip_config_builder.h
@@ -24,8 +24,7 @@
 #include <vector>
 #include <cstdint>
 
-namespace anbox {
-namespace android {
+namespace anbox::android {
 class IpConfigBuilder {
  public:
   enum class Version : std::uint32_t {
@@ -60,7 +59,5 @@ class IpConfigBuilder {
   std::vector<std::string> dns_servers_;
   std::uint32_t id_;
 };
-}  // namespace android
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/application/database.cpp
+++ b/src/anbox/application/database.cpp
@@ -20,8 +20,7 @@
 #include "anbox/system_configuration.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 const Database::Item Database::Unknown{};
 
 Database::Database() :
@@ -56,5 +55,4 @@ const Database::Item& Database::find_by_package(const std::string &package) cons
     return Unknown;
   return iter->second;
 }
-}  // namespace application
-}  // namespace anbox
+}

--- a/src/anbox/application/database.h
+++ b/src/anbox/application/database.h
@@ -24,8 +24,7 @@
 #include <map>
 #include <memory>
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 class LauncherStorage;
 class Database {
  public:
@@ -53,7 +52,5 @@ class Database {
   std::map<std::string,Item> items_;
   bool done_reset = false;
 };
-}  // namespace application
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/application/gps_info_broker.h
+++ b/src/anbox/application/gps_info_broker.h
@@ -6,12 +6,9 @@
 
 #include "anbox/do_not_copy_or_move.h"
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 struct GpsInfoBroker : public DoNotCopyOrMove {
   boost::signals2::signal<void(const std::string&)> newNmeaSentence;
 };
-}  // namespace application
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/application/launcher_storage.cpp
+++ b/src/anbox/application/launcher_storage.cpp
@@ -31,8 +31,7 @@ namespace {
 constexpr const char *snap_exe_path{"/snap/bin/anbox"};
 }
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 LauncherStorage::LauncherStorage(const fs::path &path) :
   path_(path) {}
 
@@ -122,5 +121,4 @@ void LauncherStorage::remove(const Database::Item &item) {
     fs::remove(item_icon_path);
 }
 
-}  // namespace application
-}  // namespace anbox
+}

--- a/src/anbox/application/launcher_storage.h
+++ b/src/anbox/application/launcher_storage.h
@@ -27,8 +27,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 class LauncherStorage {
  public:
   LauncherStorage(const boost::filesystem::path &path);
@@ -45,7 +44,5 @@ class LauncherStorage {
 
   boost::filesystem::path path_;
 };
-}  // namespace application
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/application/manager.h
+++ b/src/anbox/application/manager.h
@@ -27,8 +27,7 @@
 
 #include <core/property.h>
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 class Manager : public DoNotCopyOrMove {
  public:
   virtual void launch(const android::Intent &intent,
@@ -65,7 +64,5 @@ class RestrictedManager : public Manager {
   std::shared_ptr<Manager> other_;
   wm::Stack::Id launch_stack_;
 };
-} // namespace application
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/application/sensor_type.cpp
+++ b/src/anbox/application/sensor_type.cpp
@@ -4,8 +4,7 @@
 #include <string>
 #include <map>
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 
 SensorType SensorTypeHelper::FromString(const std::string& str) {
   static std::map<std::string, SensorType> nameToType;
@@ -24,5 +23,4 @@ SensorType SensorTypeHelper::FromString(const std::string& str) {
   else
     return SensorType::UnknownSensor;
 }
-}  // namespace application
-}  // namespace anbox
+}

--- a/src/anbox/application/sensor_type.h
+++ b/src/anbox/application/sensor_type.h
@@ -3,8 +3,7 @@
 
 #include <string>
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 enum SensorType {
   UnknownSensor = 0,
   AccelerationSensor = (1 << 0),
@@ -20,7 +19,5 @@ class SensorTypeHelper {
  public:
   static SensorType FromString(const std::string& str);
 };
-}  // namespace application
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/application/sensors_state.h
+++ b/src/anbox/application/sensors_state.h
@@ -7,8 +7,7 @@
 #include "anbox/do_not_copy_or_move.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 struct SensorsState : public DoNotCopyOrMove {
   SensorsState() {
     disabled_sensors = 0;
@@ -31,7 +30,5 @@ struct SensorsState : public DoNotCopyOrMove {
   double pressure;
   double humidity;
 };
-}  // namespace application
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/audio/client_info.h
+++ b/src/anbox/audio/client_info.h
@@ -20,8 +20,7 @@
 
 #include <cstdint>
 
-namespace anbox {
-namespace audio {
+namespace anbox::audio {
 struct ClientInfo {
   enum class Type : std::uint8_t {
     Playback = 0,
@@ -30,7 +29,5 @@ struct ClientInfo {
   };
   Type type;
 };
-} // namespace audio
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/audio/server.cpp
+++ b/src/anbox/audio/server.cpp
@@ -45,8 +45,7 @@ class AudioForwarder : public anbox::network::MessageProcessor {
 };
 }
 
-namespace anbox {
-namespace audio {
+namespace anbox::audio {
 Server::Server(const std::shared_ptr<Runtime>& rt, const std::shared_ptr<platform::BasePlatform> &platform) :
   platform_(platform),
   socket_file_(utils::string_format("%s/anbox_audio", SystemConfiguration::instance().socket_dir())),
@@ -105,5 +104,4 @@ void Server::create_connection_for(std::shared_ptr<boost::asio::basic_stream_soc
 int Server::next_id() {
   return next_id_.fetch_add(1);
 }
-} // namespace audio
-} // namespace anbox
+}

--- a/src/anbox/audio/server.h
+++ b/src/anbox/audio/server.h
@@ -26,11 +26,11 @@
 
 #include <atomic>
 
-namespace anbox {
-namespace network {
-class PublishedSocketConnector;
-} // namespace network
-namespace audio {
+namespace anbox::network {
+  class PublishedSocketConnector;
+} 
+
+namespace anbox::audio {
 class Server {
  public:
   Server(const std::shared_ptr<Runtime>& rt, const std::shared_ptr<platform::BasePlatform> &platform);
@@ -50,7 +50,5 @@ class Server {
   std::shared_ptr<network::Connections<network::SocketConnection>> const connections_;
   std::atomic<int> next_id_;
 };
-} // namespace audio
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/audio/sink.h
+++ b/src/anbox/audio/sink.h
@@ -22,14 +22,11 @@
 
 #include <vector>
 
-namespace anbox {
-namespace audio {
+namespace anbox::audio {
 class Sink {
  public:
   virtual ~Sink() {}
   virtual void write_data(const std::vector<std::uint8_t> &data) = 0;
 };
-} // namespace audio
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/audio/source.h
+++ b/src/anbox/audio/source.h
@@ -22,15 +22,12 @@
 
 #include <vector>
 
-namespace anbox {
-namespace audio {
+namespace anbox::audio {
 class Source {
  public:
   virtual ~Source() {}
 
   virtual void read_data(std::vector<std::uint8_t> &data) = 0;
 };
-} // namespace audio
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/bridge/android_api_stub.cpp
+++ b/src/anbox/bridge/android_api_stub.cpp
@@ -37,8 +37,7 @@ namespace {
 constexpr const std::chrono::milliseconds default_rpc_call_timeout{30000};
 } // namespace
 
-namespace anbox {
-namespace bridge {
+namespace anbox::bridge {
 AndroidApiStub::AndroidApiStub() {}
 
 AndroidApiStub::~AndroidApiStub() {}
@@ -223,5 +222,4 @@ void AndroidApiStub::task_resized(Request<protobuf::rpc::Void> *request) {
   (void)request;
   resize_task_handle_.result_received();
 }
-}  // namespace bridge
-}  // namespace anbox
+}

--- a/src/anbox/bridge/android_api_stub.h
+++ b/src/anbox/bridge/android_api_stub.h
@@ -25,16 +25,15 @@
 #include <memory>
 #include <vector>
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Void;
-}  // namespace bridge
-}  // namespace protobuf
-namespace rpc {
-class Channel;
-}  // namespace rpc
-namespace bridge {
+namespace anbox::protobuf::rpc {
+  class Void;
+}
+
+namespace anbox::rpc {
+  class Channel;
+}
+
+namespace anbox::bridge {
 class AndroidApiStub : public anbox::application::Manager {
  public:
   AndroidApiStub();
@@ -78,7 +77,5 @@ class AndroidApiStub : public anbox::application::Manager {
   graphics::Rect launch_bounds_ = graphics::Rect::Invalid;
   core::Property<bool> ready_;
 };
-}  // namespace bridge
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/bridge/platform_api_skeleton.cpp
+++ b/src/anbox/bridge/platform_api_skeleton.cpp
@@ -32,8 +32,7 @@
 #include <google/protobuf/stubs/callback.h>
 #endif
 
-namespace anbox {
-namespace bridge {
+namespace anbox::bridge {
 PlatformApiSkeleton::PlatformApiSkeleton(
     const std::shared_ptr<rpc::PendingCallCache> &pending_calls,
     const std::shared_ptr<platform::BasePlatform> &platform,
@@ -144,5 +143,4 @@ void PlatformApiSkeleton::handle_application_list_update_event(const anbox::prot
 void PlatformApiSkeleton::register_boot_finished_handler(const std::function<void()> &action) {
   boot_finished_handler_ = action;
 }
-}  // namespace bridge
-}  // namespace anbox
+}

--- a/src/anbox/bridge/platform_api_skeleton.h
+++ b/src/anbox/bridge/platform_api_skeleton.h
@@ -22,36 +22,34 @@
 #include <memory>
 
 namespace google {
-namespace protobuf {
-class Closure;
-}  // namespace protobuf
+  namespace protobuf {
+    class Closure;
+  }  // namespace protobuf
 }  // namespace google
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Void;
+namespace anbox::protobuf::rpc {
+  class Void;
 }  // namespace rpc
-namespace bridge {
-class ClipboardData;
-class BootFinishedEvent;
-class WindowStateUpdateEvent;
-class ApplicationListUpdateEvent;
+namespace anbox::protobuf::bridge {
+  class ClipboardData;
+  class BootFinishedEvent;
+  class WindowStateUpdateEvent;
+  class ApplicationListUpdateEvent;
 }  // namespace bridge
-}  // namespace protobuf
-namespace platform {
-class BasePlatform;
+
+namespace anbox::platform {
+  class BasePlatform;
 } // namespace platform
-namespace rpc {
-class PendingCallCache;
-}  // namespace rpc
-namespace wm {
-class Manager;
+namespace anbox::rpc {
+  class PendingCallCache;
+}  // nameanbox::space rpc
+namespace anbox::wm {
+  class Manager;
 }  // namespace wm
-namespace application {
-class Database;
+namespace anbox::application {
+  class Database;
 }  // namespace application
-namespace bridge {
+namespace anbox::bridge {
 class PlatformApiSkeleton {
  public:
   PlatformApiSkeleton(
@@ -84,7 +82,7 @@ class PlatformApiSkeleton {
   std::shared_ptr<application::Database> app_db_;
   std::function<void()> boot_finished_handler_;
 };
-}  // namespace bridge
-}  // namespace anbox
+}
+
 
 #endif

--- a/src/anbox/bridge/platform_message_processor.cpp
+++ b/src/anbox/bridge/platform_message_processor.cpp
@@ -22,8 +22,7 @@
 
 #include "anbox_bridge.pb.h"
 
-namespace anbox {
-namespace bridge {
+namespace anbox::bridge {
 PlatformMessageProcessor::PlatformMessageProcessor(
     const std::shared_ptr<network::MessageSender> &sender,
     const std::shared_ptr<PlatformApiSkeleton> &server,
@@ -57,5 +56,4 @@ void PlatformMessageProcessor::process_event_sequence(
     server_->handle_application_list_update_event(
         seq.application_list_update());
 }
-}  // namespace anbox
-}  // namespace network
+}

--- a/src/anbox/bridge/platform_message_processor.h
+++ b/src/anbox/bridge/platform_message_processor.h
@@ -20,8 +20,7 @@
 
 #include "anbox/rpc/message_processor.h"
 
-namespace anbox {
-namespace bridge {
+namespace anbox::bridge {
 class PlatformApiSkeleton;
 class PlatformMessageProcessor : public rpc::MessageProcessor {
  public:
@@ -37,7 +36,6 @@ class PlatformMessageProcessor : public rpc::MessageProcessor {
  private:
   std::shared_ptr<PlatformApiSkeleton> server_;
 };
-}  // namespace anbox
-}  // namespace network
+}
 
 #endif

--- a/src/anbox/build/config.h.in
+++ b/src/anbox/build/config.h.in
@@ -23,15 +23,13 @@
 #include <cstdint>
 #include <string>
 
-namespace anbox {
-namespace build {
+namespace anbox::build {
 /// @brief version marks the version
 static constexpr const char *version{"@ANBOX_VERSION@"};
 
 // path for system configuration
 static constexpr const char *default_resource_path{"@ANBOX_RESOURCE_DIR_FULL@"};
 static constexpr const char *default_data_path{"@ANBOX_STATEDIR_FULL@"};
-}  // namespace build
-}  // namespace anbox
+}
 
 #endif  // ANBOX_CONFIG_H_

--- a/src/anbox/cmds/check_features.h
+++ b/src/anbox/cmds/check_features.h
@@ -24,8 +24,7 @@
 
 #include "anbox/cli.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class CheckFeatures : public cli::CommandWithFlagsAndAction {
  public:
   CheckFeatures();
@@ -33,7 +32,5 @@ class CheckFeatures : public cli::CommandWithFlagsAndAction {
  private:
   bool sanity_check_for_features();
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/container_manager.h
+++ b/src/anbox/cmds/container_manager.h
@@ -27,8 +27,7 @@
 #include "anbox/common/loop_device.h"
 #include "anbox/common/mount_entry.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class ContainerManager : public cli::CommandWithFlagsAndAction {
  public:
   ContainerManager();
@@ -50,7 +49,5 @@ class ContainerManager : public cli::CommandWithFlagsAndAction {
   std::string container_network_gateway_;
   std::string container_network_dns_servers_;
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/install.h
+++ b/src/anbox/cmds/install.h
@@ -24,8 +24,7 @@
 
 #include "anbox/cli.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class Install : public cli::CommandWithFlagsAndAction {
  public:
   Install();
@@ -33,7 +32,5 @@ class Install : public cli::CommandWithFlagsAndAction {
  private:
   std::string apk_;
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/launch.h
+++ b/src/anbox/cmds/launch.h
@@ -26,8 +26,7 @@
 #include "anbox/wm/stack.h"
 #include "anbox/cli.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class Launch : public cli::CommandWithFlagsAndAction {
  public:
   Launch();
@@ -39,7 +38,5 @@ class Launch : public cli::CommandWithFlagsAndAction {
   wm::Stack::Id stack_ = wm::Stack::Id::Default;
   bool use_system_dbus_ = false;
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -27,14 +27,15 @@
 #include "anbox/graphics/gl_renderer_server.h"
 #include "anbox/graphics/rect.h"
 
-namespace anbox {
-namespace bridge {
-class AndroidApiStub;
-} // namespace bridge
-namespace container {
-class Client;
-}  // namespace container
-namespace cmds {
+namespace anbox::bridge {
+  class AndroidApiStub;
+}
+
+namespace anbox::container {
+  class Client;
+}
+
+namespace anbox::cmds {
 class SessionManager : public cli::CommandWithFlagsAndAction {
  public:
   SessionManager();
@@ -54,7 +55,5 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   bool no_touch_emulation_ = false;
   bool server_side_decoration_ = false;
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/system_info.h
+++ b/src/anbox/cmds/system_info.h
@@ -24,13 +24,10 @@
 
 #include "anbox/cli.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class SystemInfo : public cli::CommandWithFlagsAndAction {
  public:
   SystemInfo();
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/version.h
+++ b/src/anbox/cmds/version.h
@@ -26,13 +26,10 @@
 
 #include "anbox/cli.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class Version : public cli::CommandWithFlagsAndAction {
  public:
   Version();
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/cmds/wait_ready.h
+++ b/src/anbox/cmds/wait_ready.h
@@ -24,8 +24,7 @@
 
 #include "anbox/cli.h"
 
-namespace anbox {
-namespace cmds {
+namespace anbox::cmds {
 class WaitReady : public cli::CommandWithFlagsAndAction {
  public:
   WaitReady();
@@ -33,7 +32,5 @@ class WaitReady : public cli::CommandWithFlagsAndAction {
  private:
   bool use_system_dbus_ = false;
 };
-}  // namespace cmds
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/binary_writer.cpp
+++ b/src/anbox/common/binary_writer.cpp
@@ -31,8 +31,7 @@ bool is_little_endian() {
 }
 }
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 
 BinaryWriter::BinaryWriter(std::vector<std::uint8_t>::iterator begin,
                            std::vector<std::uint8_t>::iterator end) :
@@ -102,5 +101,4 @@ void BinaryWriter::write_string_with_size(const char *s, std::size_t size) {
 std::size_t BinaryWriter::bytes_written() const {
   return current_ - begin_;
 }
-} // namespace common
-} // namespace anbox
+}

--- a/src/anbox/common/binary_writer.h
+++ b/src/anbox/common/binary_writer.h
@@ -23,8 +23,7 @@
 #include <vector>
 #include <string>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class BinaryWriter {
  public:
   enum class Order {
@@ -51,7 +50,5 @@ class BinaryWriter {
   std::vector<std::uint8_t>::iterator end_;
   Order byte_order_;
 };
-} // namespace common
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/binder_device.cpp
+++ b/src/anbox/common/binder_device.cpp
@@ -29,8 +29,7 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 std::unique_ptr<BinderDevice> BinderDevice::create(const std::string& path) {
   return std::unique_ptr<BinderDevice>(new BinderDevice(path));
 }
@@ -45,5 +44,4 @@ BinderDevice::~BinderDevice() {
   if (::unlink(path_.c_str()) < 0)
     ERROR("Failed to remove binder node %s: %s", path_, std::strerror(errno));
 }
-} // namespace common
-} // namespace anbox
+}

--- a/src/anbox/common/binder_device.h
+++ b/src/anbox/common/binder_device.h
@@ -22,8 +22,7 @@
 
 #include <boost/filesystem/path.hpp>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class BinderDevice {
  public:
   static std::unique_ptr<BinderDevice> create(const std::string& path);
@@ -37,7 +36,5 @@ class BinderDevice {
 
   const std::string path_;
 };
-} // namespace common
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/binder_device_allocator.cpp
+++ b/src/anbox/common/binder_device_allocator.cpp
@@ -39,8 +39,7 @@ const constexpr char* binderfs_control_path{BINDERFS_PATH "/binder-control"};
 const constexpr char* default_binder_device_name{"binder"};
 } // namespace
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 bool BinderDeviceAllocator::is_supported() {
   return fs::exists(binderfs_control_path);
 }
@@ -80,5 +79,4 @@ std::unique_ptr<BinderDevice> BinderDeviceAllocator::new_device() {
 
   return BinderDevice::create(path);
 }
-} // namespace common
-} // namespace anbox
+}

--- a/src/anbox/common/binder_device_allocator.h
+++ b/src/anbox/common/binder_device_allocator.h
@@ -20,15 +20,12 @@
 
 #include <memory>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class BinderDevice;
 class BinderDeviceAllocator {
  public:
   static bool is_supported();
   static std::unique_ptr<BinderDevice> new_device();
 };
-} // namespace common
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/dispatcher.h
+++ b/src/anbox/common/dispatcher.h
@@ -25,8 +25,7 @@
 
 #include <memory>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class Dispatcher : public DoNotCopyOrMove {
  public:
   typedef std::function<void()> Task;
@@ -38,7 +37,5 @@ class Dispatcher : public DoNotCopyOrMove {
 
 std::shared_ptr<Dispatcher> create_dispatcher_for_runtime(
     const std::shared_ptr<Runtime>&);
-}  // namespace common
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/loop_device.cpp
+++ b/src/anbox/common/loop_device.cpp
@@ -25,8 +25,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 std::shared_ptr<LoopDevice> LoopDevice::create(const boost::filesystem::path &path) {
   const auto fd = ::open(path.c_str(), O_RDWR);
   if (fd < 0)
@@ -61,5 +60,4 @@ bool LoopDevice::attach_file(const boost::filesystem::path &file_path) {
 
   return true;
 }
-} // namespace common
-} // namespace anbox
+}

--- a/src/anbox/common/loop_device.h
+++ b/src/anbox/common/loop_device.h
@@ -22,8 +22,7 @@
 
 #include <boost/filesystem/path.hpp>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class LoopDevice {
  public:
   static std::shared_ptr<LoopDevice> create(const boost::filesystem::path &path);
@@ -40,7 +39,5 @@ class LoopDevice {
   Fd fd_;
   boost::filesystem::path path_;
 };
-} // namespace common
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/loop_device_allocator.cpp
+++ b/src/anbox/common/loop_device_allocator.cpp
@@ -36,8 +36,7 @@ const constexpr char *loop_control_path{"/dev/loop-control"};
 const constexpr char *base_loop_path{"/dev/loop"};
 }
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 std::shared_ptr<LoopDevice> LoopDeviceAllocator::new_device() {
   const auto ctl_fd = ::open(loop_control_path, O_RDWR);
   if (ctl_fd < 0)
@@ -51,5 +50,4 @@ std::shared_ptr<LoopDevice> LoopDeviceAllocator::new_device() {
 
   return LoopDevice::create(utils::string_format("%s%d", base_loop_path, device_nr));
 }
-} // namespace common
-} // namespace anbox
+}

--- a/src/anbox/common/loop_device_allocator.h
+++ b/src/anbox/common/loop_device_allocator.h
@@ -20,14 +20,11 @@
 
 #include <memory>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class LoopDevice;
 class LoopDeviceAllocator {
  public:
   static std::shared_ptr<LoopDevice> new_device();
 };
-} // namespace common
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/message_channel.cpp
+++ b/src/anbox/common/message_channel.cpp
@@ -14,8 +14,7 @@
 
 #include "anbox/common/message_channel.h"
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 MessageChannelBase::MessageChannelBase(size_t capacity) : pos_(0U),
                                                           count_(0U),
                                                           capacity_(capacity),
@@ -60,5 +59,4 @@ void MessageChannelBase::after_read() {
   can_write_.notify_one();
   lock_.unlock();
 }
-}  // namespace common
-}  // namespace anbox
+}

--- a/src/anbox/common/message_channel.h
+++ b/src/anbox/common/message_channel.h
@@ -20,8 +20,7 @@
 #include <condition_variable>
 #include <mutex>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 
 // Base non-templated class used to reduce the amount of template
 // specialization.
@@ -93,7 +92,5 @@ class MessageChannel : public MessageChannelBase {
  private:
   T mItems[CAPACITY];
 };
-}  // namespace common
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/mount_entry.cpp
+++ b/src/anbox/common/mount_entry.cpp
@@ -21,8 +21,7 @@
 
 #include <sys/mount.h>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 std::shared_ptr<MountEntry> MountEntry::create(const boost::filesystem::path &src, const boost::filesystem::path &target,
                                                const std::string &fs_type, unsigned long flags, const std::string &data) {
   auto entry = std::shared_ptr<MountEntry>(new MountEntry(target));
@@ -74,5 +73,4 @@ MountEntry::~MountEntry() {
 
   ::umount(target_.c_str());
 }
-} // namespace common
-} // namespace anbox
+}

--- a/src/anbox/common/mount_entry.h
+++ b/src/anbox/common/mount_entry.h
@@ -20,8 +20,7 @@
 
 #include <boost/filesystem/path.hpp>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 class LoopDevice;
 class MountEntry {
  public:
@@ -42,7 +41,5 @@ class MountEntry {
   std::shared_ptr<LoopDevice> loop_;
   boost::filesystem::path target_;
 };
-} // namespace common
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/common/scope_ptr.h
+++ b/src/anbox/common/scope_ptr.h
@@ -19,8 +19,7 @@
 
 #include <stdlib.h>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 
 struct FreeDelete {
   template <class T>
@@ -95,5 +94,4 @@ makeCustomScopedPtr(T data, Func deleter) {
       data, FuncDelete<typename std::decay<Func>::type>(deleter));
 }
 
-}  // namespace common
-}  // namespace anbox
+}

--- a/src/anbox/common/small_vector.h
+++ b/src/anbox/common/small_vector.h
@@ -45,8 +45,7 @@
 // but fill free to add the ones you need.
 //
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 
 //
 // Forward-declare the 'real' small vector class.
@@ -372,5 +371,4 @@ class SmallFixedVector : public SmallVector<T> {
   } mData;
 };
 
-}  // namespace common
-}  // namespace anbox
+}

--- a/src/anbox/common/wait_handle.cpp
+++ b/src/anbox/common/wait_handle.cpp
@@ -19,8 +19,7 @@
 
 #include "anbox/common/wait_handle.h"
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 WaitHandle::WaitHandle()
     : guard(), wait_condition(), expecting(0), received(0) {}
 
@@ -75,5 +74,4 @@ bool WaitHandle::is_pending() {
   std::unique_lock<std::mutex> lock(guard);
   return expecting > 0 && received != expecting;
 }
-}  // namespace common
-}  // namespace anbox
+}

--- a/src/anbox/common/wait_handle.h
+++ b/src/anbox/common/wait_handle.h
@@ -24,8 +24,7 @@
 #include <condition_variable>
 #include <mutex>
 
-namespace anbox {
-namespace common {
+namespace anbox::common {
 struct WaitHandle {
  public:
   WaitHandle();
@@ -47,7 +46,5 @@ struct WaitHandle {
   int expecting;
   int received;
 };
-}  // namespace common
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/container/client.cpp
+++ b/src/anbox/container/client.cpp
@@ -27,8 +27,7 @@
 namespace ba = boost::asio;
 namespace bs = boost::system;
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 Client::Client(const std::shared_ptr<Runtime> &rt)
     : messenger_(std::make_shared<network::LocalSocketMessenger>(
           SystemConfiguration::instance().container_socket_path(), rt)),
@@ -79,5 +78,4 @@ void Client::on_read_size(const boost::system::error_code &error,
 
   if (processor_->process_data(data)) read_next_message();
 }
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/client.h
+++ b/src/anbox/container/client.h
@@ -21,16 +21,17 @@
 #include "anbox/container/configuration.h"
 #include "anbox/runtime.h"
 
-namespace anbox {
-namespace rpc {
-class PendingCallCache;
-class Channel;
-class MessageProcessor;
-}  // namespace rpc
-namespace network {
-class LocalSocketMessenger;
-}  // namespace network
-namespace container {
+namespace anbox::rpc {
+  class PendingCallCache;
+  class Channel;
+  class MessageProcessor;
+}
+
+namespace anbox::network {
+  class LocalSocketMessenger;
+}
+
+namespace anbox::container {
 class ManagementApiStub;
 class Client {
  public:
@@ -57,7 +58,5 @@ class Client {
   std::array<std::uint8_t, 8192> buffer_;
   TerminateCallback terminate_callback_;
 };
-}  // namespace container
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/container/configuration.h
+++ b/src/anbox/container/configuration.h
@@ -22,8 +22,7 @@
 #include <vector>
 #include <unordered_map>
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 struct DeviceSpecification {
   uint32_t permission;
   std::string old_device_name = "";
@@ -34,7 +33,5 @@ struct Configuration {
   std::unordered_map<std::string, DeviceSpecification> devices;
   std::vector<std::string> extra_properties;
 };
-}  // namespace container
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/container/container.cpp
+++ b/src/anbox/container/container.cpp
@@ -17,8 +17,6 @@
 
 #include "anbox/container/container.h"
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 Container::~Container() {}
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/container.h
+++ b/src/anbox/container/container.h
@@ -23,8 +23,7 @@
 #include <map>
 #include <string>
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 class Container {
  public:
   virtual ~Container();
@@ -43,7 +42,5 @@ class Container {
   // Get the current container state
   virtual State state() = 0;
 };
-}  // namespace container
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -89,8 +89,7 @@ constexpr int device_minor(dev_t dev) {
 }
 } // namespace
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 LxcContainer::LxcContainer(bool privileged,
                            bool rootfs_overlay,
                            const std::string& container_network_address,
@@ -513,5 +512,4 @@ void LxcContainer::set_config_item(const std::string &key,
 }
 
 Container::State LxcContainer::state() { return state_; }
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/lxc_container.h
+++ b/src/anbox/container/lxc_container.h
@@ -26,11 +26,11 @@
 
 #include <lxc/lxccontainer.h>
 
-namespace anbox {
-namespace common {
-class BinderDevice;
-} // namespace common
-namespace container {
+namespace anbox::common {
+  class BinderDevice;
+}
+
+namespace anbox::container {
 class LxcContainer : public Container {
  public:
   LxcContainer(bool privileged,
@@ -65,7 +65,5 @@ class LxcContainer : public Container {
 
 // get_id_map() is published for unit testing
 std::vector<std::string> get_id_map(uid_t uid, gid_t gid);
-}  // namespace container
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/container/management_api_message_processor.cpp
+++ b/src/anbox/container/management_api_message_processor.cpp
@@ -22,8 +22,7 @@
 #include "anbox_bridge.pb.h"
 #include "anbox_container.pb.h"
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 ManagementApiMessageProcessor::ManagementApiMessageProcessor(
     const std::shared_ptr<network::MessageSender> &sender,
     const std::shared_ptr<rpc::PendingCallCache> &pending_calls,
@@ -41,5 +40,4 @@ void ManagementApiMessageProcessor::dispatch(rpc::Invocation const &invocation) 
 
 void ManagementApiMessageProcessor::process_event_sequence(
     const std::string &) {}
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/management_api_skeleton.cpp
+++ b/src/anbox/container/management_api_skeleton.cpp
@@ -29,8 +29,7 @@
 #include <google/protobuf/stubs/callback.h>
 #endif
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 ManagementApiSkeleton::ManagementApiSkeleton(
     const std::shared_ptr<rpc::PendingCallCache> &pending_calls,
     const std::shared_ptr<Container> &container)
@@ -96,5 +95,4 @@ void ManagementApiSkeleton::stop_container(
 
   done->Run();
 }
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/management_api_skeleton.h
+++ b/src/anbox/container/management_api_skeleton.h
@@ -21,25 +21,23 @@
 #include <memory>
 
 namespace google {
-namespace protobuf {
-class Closure;
-}  // namespace protobuf
-}  // namespace google
+  namespace protobuf {
+    class Closure;
+  }
+}
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Void;
-}  // namespace rpc
-namespace container {
-class StartContainer;
-class StopContainer;
-}  // namespace container
-}  // namespace protobuf
-namespace rpc {
-class PendingCallCache;
-}  // namespace rpc
-namespace container {
+namespace anbox::protobuf::rpc {
+  class Void;
+}
+namespace anbox::protobuf::container {
+  class StartContainer;
+  class StopContainer;
+}
+
+namespace anbox::rpc {
+  class PendingCallCache;
+}
+namespace anbox::container {
 class Container;
 class ManagementApiSkeleton {
  public:
@@ -60,7 +58,6 @@ class ManagementApiSkeleton {
   std::shared_ptr<rpc::PendingCallCache> pending_calls_;
   std::shared_ptr<Container> container_;
 };
-}  // namespace container
-}  // namespace anbox
+}
 
 #endif

--- a/src/anbox/container/management_api_stub.cpp
+++ b/src/anbox/container/management_api_stub.cpp
@@ -26,8 +26,7 @@
 #include <google/protobuf/stubs/callback.h>
 #endif
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 
 const std::chrono::milliseconds ManagementApiStub::stop_waiting_timeout{3000};
 
@@ -102,5 +101,4 @@ void ManagementApiStub::container_stopped(Request<protobuf::rpc::Void> *request)
   request->wh.result_received();
 }
 
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/management_api_stub.h
+++ b/src/anbox/container/management_api_stub.h
@@ -24,16 +24,15 @@
 
 #include <memory>
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Void;
-}  // namespace rpc
-}  // namespace protobuf
-namespace rpc {
-class Channel;
-}  // namespace rpc
-namespace container {
+namespace anbox::protobuf::rpc {
+  class Void;
+}
+
+namespace anbox::rpc {
+  class Channel;
+}
+
+namespace anbox::container {
 class ManagementApiStub : public DoNotCopyOrMove {
  public:
   ManagementApiStub(const std::shared_ptr<rpc::Channel> &channel);
@@ -58,7 +57,5 @@ class ManagementApiStub : public DoNotCopyOrMove {
   std::shared_ptr<rpc::Channel> channel_;
   static const std::chrono::milliseconds stop_waiting_timeout;
 };
-}  // namespace container
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/container/service.cpp
+++ b/src/anbox/container/service.cpp
@@ -32,8 +32,7 @@
 
 namespace fs = boost::filesystem;
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 std::shared_ptr<Service> Service::create(const std::shared_ptr<Runtime> &rt, const Configuration &config) {
   auto sp = std::shared_ptr<Service>(new Service(rt, config));
 
@@ -102,5 +101,4 @@ void Service::new_client(std::shared_ptr<boost::asio::local::stream_protocol::so
   connections_->add(connection);
   connection->read_next_message();
 }
-}  // namespace container
-}  // namespace anbox
+}

--- a/src/anbox/container/service.h
+++ b/src/anbox/container/service.h
@@ -26,8 +26,7 @@
 #include "anbox/network/socket_connection.h"
 #include "anbox/runtime.h"
 
-namespace anbox {
-namespace container {
+namespace anbox::container {
 class Service : public std::enable_shared_from_this<Service> {
  public:
   struct Configuration {
@@ -57,7 +56,5 @@ class Service : public std::enable_shared_from_this<Service> {
   std::shared_ptr<Container> backend_;
   Configuration config_;
 };
-}  // namespace container
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/dbus/bus.cpp
+++ b/src/anbox/dbus/bus.cpp
@@ -18,8 +18,7 @@
 #include "anbox/dbus/bus.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace dbus {
+namespace anbox::dbus {
 Bus::Bus(Type type) {
   int ret = 0;
   switch (type) {
@@ -80,5 +79,4 @@ void Bus::worker_main() {
       break;
   }
 }
-}  // namespace dbus
-}  // namespace anbox
+}

--- a/src/anbox/dbus/bus.h
+++ b/src/anbox/dbus/bus.h
@@ -27,8 +27,7 @@
 
 #include <systemd/sd-bus.h>
 
-namespace anbox {
-namespace dbus {
+namespace anbox::dbus {
 class Bus : public DoNotCopyOrMove {
  public:
   enum class Type {
@@ -53,7 +52,5 @@ class Bus : public DoNotCopyOrMove {
   std::atomic_bool running_{false};
 };
 using BusPtr = std::shared_ptr<Bus>;
-}  // namespace dbus
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/dbus/interface.h
+++ b/src/anbox/dbus/interface.h
@@ -18,15 +18,10 @@
 #ifndef ANBOX_DBUS_INTERFACE_H_
 #define ANBOX_DBUS_INTERFACE_H_
 
-namespace anbox {
-namespace dbus {
-namespace interface {
+namespace anbox::dbus::interface {
 struct Service {
   static inline const char* name() { return "org.anbox"; }
   static inline const char* path() { return "/org/anbox"; }
 };
-}  // namespace interface
-}  // namespace dbus
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/buffer_queue.cpp
+++ b/src/anbox/graphics/buffer_queue.cpp
@@ -14,8 +14,7 @@
 
 #include "anbox/graphics/buffer_queue.h"
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 BufferQueue::BufferQueue(size_t capacity)
     : capacity_(capacity), buffers_(new Buffer[capacity]) {}
 
@@ -89,5 +88,4 @@ void BufferQueue::close_locked() {
     can_pop_.notify_all();
   }
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/buffer_queue.h
+++ b/src/anbox/graphics/buffer_queue.h
@@ -21,8 +21,7 @@
 #include <memory>
 #include <mutex>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 using Buffer = anbox::common::SmallFixedVector<char, 512>;
 
 class BufferQueue {
@@ -50,7 +49,5 @@ class BufferQueue {
   std::condition_variable can_pop_;
 };
 
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/buffered_io_stream.cpp
+++ b/src/anbox/graphics/buffered_io_stream.cpp
@@ -18,8 +18,7 @@
 #include "anbox/graphics/buffered_io_stream.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 BufferedIOStream::BufferedIOStream(
     const std::shared_ptr<anbox::network::SocketMessenger> &messenger,
     size_t buffer_size)
@@ -133,5 +132,4 @@ void BufferedIOStream::thread_main() {
     }
   }
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/buffered_io_stream.h
+++ b/src/anbox/graphics/buffered_io_stream.h
@@ -26,8 +26,7 @@
 #include <memory>
 #include <thread>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class BufferedIOStream : public IOStream {
  public:
   static const size_t default_buffer_size{384};
@@ -59,7 +58,5 @@ class BufferedIOStream : public IOStream {
   BufferQueue out_queue_;
   std::thread worker_thread_;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/density.cpp
+++ b/src/anbox/graphics/density.cpp
@@ -17,8 +17,7 @@
 
 #include "anbox/graphics/density.h"
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 DensityType current_density() {
   return DensityType::medium;
 }
@@ -26,5 +25,4 @@ DensityType current_density() {
 int dp_to_pixel(unsigned int dp) {
   return dp * static_cast<unsigned int>(current_density()) / static_cast<unsigned int>(DensityType::medium);
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/density.h
+++ b/src/anbox/graphics/density.h
@@ -18,8 +18,7 @@
 #ifndef ANBOX_GRAPHICS_DENSITY_H_
 #define ANBOX_GRAPHICS_DENSITY_H_
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 /**
  * @brief Defines different types of density being used in an Android system.
  * See the
@@ -38,7 +37,5 @@ enum class DensityType {
 
 DensityType current_density();
 int dp_to_pixel(unsigned int dp);
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/emugl/DisplayManager.cpp
+++ b/src/anbox/graphics/emugl/DisplayManager.cpp
@@ -17,9 +17,7 @@
 
 #include "DisplayManager.h"
 
-namespace anbox {
-namespace graphics {
-namespace emugl {
+namespace anbox::graphics::emugl {
 std::shared_ptr<DisplayInfo> DisplayInfo::get() {
   static auto info = std::make_shared<DisplayInfo>();
   return info;
@@ -33,6 +31,4 @@ void DisplayInfo::set_resolution(const std::uint32_t &vertical, const std::uint3
 std::uint32_t DisplayInfo::vertical_resolution() const { return vertical_resolution_; }
 
 std::uint32_t DisplayInfo::horizontal_resolution() const { return horizontal_resolution_; }
-} // namespace emugl
-} // namespace graphics
-} // namespace anbox
+}

--- a/src/anbox/graphics/emugl/DisplayManager.h
+++ b/src/anbox/graphics/emugl/DisplayManager.h
@@ -21,9 +21,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace anbox {
-namespace graphics {
-namespace emugl {
+namespace anbox::graphics::emugl {
 class DisplayInfo {
  public:
   DisplayInfo() = default;
@@ -39,8 +37,5 @@ class DisplayInfo {
   std::uint32_t vertical_resolution_ = 1280;
   std::uint32_t horizontal_resolution_ = 720;
 };
-} // namespace emugl
-} // namespace graphics
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/emugl/RenderApi.cpp
+++ b/src/anbox/graphics/emugl/RenderApi.cpp
@@ -33,9 +33,7 @@ constexpr const char *default_egl_lib{"libEGL.so.1"};
 constexpr const char *default_glesv2_lib{"libGLESv2.so.2"};
 }
 
-namespace anbox {
-namespace graphics {
-namespace emugl {
+namespace anbox::graphics::emugl {
 std::vector<GLLibrary> default_gl_libraries() {
   return std::vector<GLLibrary>{
     {GLLibrary::Type::EGL, default_egl_lib},
@@ -83,6 +81,4 @@ bool initialize(const std::vector<GLLibrary> &libs, emugl_logger_struct *log_fun
 
   return true;
 }
-}  // namespace emugl
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/emugl/RenderApi.h
+++ b/src/anbox/graphics/emugl/RenderApi.h
@@ -28,9 +28,7 @@ typedef struct {
   logger_t fine;
 } emugl_logger_struct;
 
-namespace anbox {
-namespace graphics {
-namespace emugl {
+namespace anbox::graphics::emugl {
 struct GLLibrary {
   enum class Type { EGL, GLESv1, GLESv2 };
   Type type;
@@ -40,8 +38,5 @@ struct GLLibrary {
 std::vector<GLLibrary> default_gl_libraries();
 
 bool initialize(const std::vector<GLLibrary> &libs, emugl_logger_struct *log_funcs, logger_t crash_func);
-}  // namespace emugl
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/emugl/RenderControl.h
+++ b/src/anbox/graphics/emugl/RenderControl.h
@@ -24,12 +24,9 @@
 
 class Renderer;
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class LayerComposer;
-}  // namespace graphics
-}  // namespace anbox
-
+}
 void initRenderControlContext(renderControl_decoder_context_t *dec);
 void registerLayerComposer(
     const std::shared_ptr<anbox::graphics::LayerComposer> &c);

--- a/src/anbox/graphics/gl_extensions.h
+++ b/src/anbox/graphics/gl_extensions.h
@@ -21,8 +21,7 @@
 #include <stdexcept>
 #include <string.h>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class GLExtensions {
  public:
   GLExtensions(char const* extensions) : extensions{extensions} {
@@ -50,7 +49,5 @@ class GLExtensions {
  private:
   char const* extensions;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/gl_renderer_server.cpp
+++ b/src/anbox/graphics/gl_renderer_server.cpp
@@ -65,8 +65,7 @@ void logger_write(const emugl::LogLevel &level, const char *format, ...) {
 }
 }
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 GLRendererServer::GLRendererServer(const Config &config, const std::shared_ptr<wm::Manager> &wm)
     : renderer_(std::make_shared<::Renderer>()) {
 
@@ -108,5 +107,4 @@ GLRendererServer::GLRendererServer(const Config &config, const std::shared_ptr<w
 }
 
 GLRendererServer::~GLRendererServer() { renderer_->finalize(); }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/gl_renderer_server.h
+++ b/src/anbox/graphics/gl_renderer_server.h
@@ -23,14 +23,15 @@
 
 class Renderer;
 
-namespace anbox {
-namespace input {
-class Manager;
-}  // namespace input
-namespace wm {
-class Manager;
-}  // namespace wm
-namespace graphics {
+namespace anbox::input {
+  class Manager;
+}
+
+namespace anbox::wm {
+  class Manager;
+}
+
+namespace anbox::graphics {
 class LayerComposer;
 class GLRendererServer {
  public:
@@ -58,7 +59,5 @@ class GLRendererServer {
   std::shared_ptr<LayerComposer> composer_;
 };
 
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/layer_composer.cpp
+++ b/src/anbox/graphics/layer_composer.cpp
@@ -20,8 +20,7 @@
 #include "anbox/logger.h"
 #include "anbox/wm/manager.h"
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 LayerComposer::LayerComposer(const std::shared_ptr<Renderer> renderer, const std::shared_ptr<Strategy> &strategy)
     : renderer_(renderer), strategy_(strategy) {}
 
@@ -35,5 +34,4 @@ void LayerComposer::submit_layers(const RenderableList &renderables) {
                     w.second);
   }
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/layer_composer.h
+++ b/src/anbox/graphics/layer_composer.h
@@ -23,12 +23,12 @@
 #include <memory>
 #include <map>
 
-namespace anbox {
-namespace wm {
-class Manager;
-class Window;
-}  // namespace wm
-namespace graphics {
+namespace anbox::wm {
+  class Manager;
+  class Window;
+}
+
+namespace anbox::graphics {
 class LayerComposer {
  public:
   class Strategy {
@@ -49,7 +49,5 @@ class LayerComposer {
   std::shared_ptr<Renderer> renderer_;
   std::shared_ptr<Strategy> strategy_;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/multi_window_composer_strategy.cpp
+++ b/src/anbox/graphics/multi_window_composer_strategy.cpp
@@ -19,8 +19,7 @@
 #include "anbox/wm/manager.h"
 #include "anbox/utils.h"
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 MultiWindowComposerStrategy::MultiWindowComposerStrategy(const std::shared_ptr<wm::Manager> &wm) : wm_(wm) {}
 
 std::map<std::shared_ptr<wm::Window>, RenderableList> MultiWindowComposerStrategy::process_layers(const RenderableList &renderables) {
@@ -82,5 +81,4 @@ std::map<std::shared_ptr<wm::Window>, RenderableList> MultiWindowComposerStrateg
 
   return win_layers;
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/multi_window_composer_strategy.h
+++ b/src/anbox/graphics/multi_window_composer_strategy.h
@@ -22,8 +22,7 @@
 
 #include <memory>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class MultiWindowComposerStrategy : public LayerComposer::Strategy {
  public:
   MultiWindowComposerStrategy(const std::shared_ptr<wm::Manager> &wm);
@@ -34,7 +33,5 @@ class MultiWindowComposerStrategy : public LayerComposer::Strategy {
 private:
   std::shared_ptr<wm::Manager> wm_;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/opengles_message_processor.cpp
+++ b/src/anbox/graphics/opengles_message_processor.cpp
@@ -27,8 +27,7 @@
 #include <functional>
 #include <queue>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 std::mutex OpenGlesMessageProcessor::global_lock{};
 
 OpenGlesMessageProcessor::OpenGlesMessageProcessor(
@@ -61,5 +60,4 @@ bool OpenGlesMessageProcessor::process_data(
   stream->post_data(std::move(buffer));
   return true;
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/opengles_message_processor.h
+++ b/src/anbox/graphics/opengles_message_processor.h
@@ -32,8 +32,7 @@ class IOStream;
 class RenderThread;
 class Renderer;
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class OpenGlesMessageProcessor : public network::MessageProcessor {
  public:
   OpenGlesMessageProcessor(
@@ -50,7 +49,5 @@ class OpenGlesMessageProcessor : public network::MessageProcessor {
   std::shared_ptr<IOStream> stream_;
   std::shared_ptr<RenderThread> render_thread_;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/primitives.h
+++ b/src/anbox/graphics/primitives.h
@@ -22,8 +22,7 @@
 
 #include <GLES2/gl2.h>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 struct Vertex {
   GLfloat position[3];
   GLfloat texcoord[2];
@@ -41,7 +40,5 @@ struct Primitive {
   int nvertices;
   Vertex vertices[max_vertices];
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/program_family.cpp
+++ b/src/anbox/graphics/program_family.cpp
@@ -23,8 +23,7 @@
 #include <string>
 #include <stdexcept>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 void ProgramFamily::Shader::init(GLenum type, const GLchar* src) {
   if (!id) {
     id = s_gles2.glCreateShader(type);
@@ -92,5 +91,4 @@ GLuint ProgramFamily::add_program(const GLchar* const vshader_src,
 
   return p.id;
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/program_family.h
+++ b/src/anbox/graphics/program_family.h
@@ -25,8 +25,7 @@
 
 #include <GLES2/gl2.h>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 /**
  * ProgramFamily represents a set of GLSL programs that are closely
  * related. Programs which point to the same shader source strings will be
@@ -59,7 +58,5 @@ class ProgramFamily {
   };
   std::map<ShaderPair, Program> program;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif  // MIR_RENDERER_GL_PROGRAM_FAMILY_H_

--- a/src/anbox/graphics/rect.cpp
+++ b/src/anbox/graphics/rect.cpp
@@ -23,8 +23,7 @@
 
 #include <boost/lexical_cast.hpp>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 const Rect Rect::Invalid{-1, -1, -1, -1};
 const Rect Rect::Empty{0, 0, 0, 0};
 
@@ -83,5 +82,4 @@ try {
 } catch (...) {
   return in;
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/rect.h
+++ b/src/anbox/graphics/rect.h
@@ -22,8 +22,7 @@
 
 #include <ostream>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class Rect {
  public:
   static const Rect Invalid;
@@ -76,7 +75,5 @@ class Rect {
 
 std::ostream &operator<<(std::ostream &out, const Rect &rect);
 std::istream& operator>>(std::istream& in, anbox::graphics::Rect &rect);
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/renderer.h
+++ b/src/anbox/graphics/renderer.h
@@ -22,8 +22,7 @@
 
 #include <EGL/egl.h>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class Renderer {
  public:
   virtual ~Renderer() {}
@@ -32,7 +31,5 @@ class Renderer {
                     const anbox::graphics::Rect& window_frame,
                     const RenderableList& renderables) = 0;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/graphics/single_window_composer_strategy.cpp
+++ b/src/anbox/graphics/single_window_composer_strategy.cpp
@@ -24,8 +24,7 @@ namespace {
 const constexpr char *sprite_name{"Sprite"};
 }
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 SingleWindowComposerStrategy::SingleWindowComposerStrategy(const std::shared_ptr<wm::Manager> &wm) : wm_(wm) {}
 
 std::map<std::shared_ptr<wm::Window>, RenderableList> SingleWindowComposerStrategy::process_layers(const RenderableList &renderables) {
@@ -46,5 +45,4 @@ std::map<std::shared_ptr<wm::Window>, RenderableList> SingleWindowComposerStrate
   win_layers.insert({window, final_renderables});
   return win_layers;
 }
-}  // namespace graphics
-}  // namespace anbox
+}

--- a/src/anbox/graphics/single_window_composer_strategy.h
+++ b/src/anbox/graphics/single_window_composer_strategy.h
@@ -22,8 +22,7 @@
 
 #include <memory>
 
-namespace anbox {
-namespace graphics {
+namespace anbox::graphics {
 class SingleWindowComposerStrategy : public LayerComposer::Strategy {
  public:
   SingleWindowComposerStrategy(const std::shared_ptr<wm::Manager> &wm);
@@ -34,7 +33,5 @@ class SingleWindowComposerStrategy : public LayerComposer::Strategy {
 private:
   std::shared_ptr<wm::Manager> wm_;
 };
-}  // namespace graphics
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/input/device.cpp
+++ b/src/anbox/input/device.cpp
@@ -24,8 +24,7 @@
 
 #include <time.h>
 
-namespace anbox {
-namespace input {
+namespace anbox::input {
 std::shared_ptr<Device> Device::create(
     const std::string &path, const std::shared_ptr<Runtime> &runtime) {
   auto sp = std::make_shared<Device>();
@@ -168,5 +167,4 @@ void Device::new_client(
   // side can properly configure itself for this input device
   connection->send(reinterpret_cast<char const *>(&info_), sizeof(info_));
 }
-}  // namespace input
-}  // namespace anbox
+}

--- a/src/anbox/input/device.h
+++ b/src/anbox/input/device.h
@@ -27,8 +27,7 @@
 
 #include <linux/input.h>
 
-namespace anbox {
-namespace input {
+namespace anbox::input {
 struct Event {
   std::uint16_t type;
   std::uint16_t code;
@@ -97,7 +96,5 @@ class Device : public std::enable_shared_from_this<Device> {
   std::shared_ptr<network::Connections<network::SocketConnection>> connections_;
   Info info_;
 };
-}  // namespace input
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/input/manager.cpp
+++ b/src/anbox/input/manager.cpp
@@ -23,8 +23,7 @@
 
 #include <boost/format.hpp>
 
-namespace anbox {
-namespace input {
+namespace anbox::input {
 Manager::Manager(const std::shared_ptr<Runtime> &runtime) : runtime_(runtime) {
   const auto dir = SystemConfiguration::instance().input_device_dir();
   utils::ensure_paths({dir});
@@ -53,5 +52,4 @@ std::string Manager::build_device_path(const std::uint32_t &id) {
   return (boost::format("%1%/event%2%") % SystemConfiguration::instance().input_device_dir() % id).str();
 }
 
-}  // namespace input
-}  // namespace anbox
+}

--- a/src/anbox/input/manager.h
+++ b/src/anbox/input/manager.h
@@ -21,9 +21,11 @@
 #include <map>
 #include <memory>
 
-namespace anbox {
-class Runtime;
-namespace input {
+namespace anbox{
+  class Runtime;
+}
+
+namespace anbox::input {
 class Device;
 class Manager {
  public:
@@ -39,7 +41,5 @@ class Manager {
   std::shared_ptr<Runtime> runtime_;
   std::map<std::uint32_t, std::shared_ptr<Device>> devices_;
 };
-}  // namespace input
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/base_socket_messenger.cpp
+++ b/src/anbox/network/base_socket_messenger.cpp
@@ -35,8 +35,7 @@ namespace {
 unsigned int const serialization_buffer_size = 2048;
 }
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 template <typename stream_protocol>
 BaseSocketMessenger<stream_protocol>::BaseSocketMessenger() {}
 
@@ -153,5 +152,4 @@ void BaseSocketMessenger<stream_protocol>::close() {
 
 template class BaseSocketMessenger<boost::asio::local::stream_protocol>;
 template class BaseSocketMessenger<boost::asio::ip::tcp>;
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/base_socket_messenger.h
+++ b/src/anbox/network/base_socket_messenger.h
@@ -25,8 +25,7 @@
 #include <boost/asio.hpp>
 #include <mutex>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 template <typename stream_protocol>
 class BaseSocketMessenger : public SocketMessenger {
  public:
@@ -59,7 +58,5 @@ class BaseSocketMessenger : public SocketMessenger {
   anbox::Fd socket_fd;
   std::mutex message_lock;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/connection_context.cpp
+++ b/src/anbox/network/connection_context.cpp
@@ -17,12 +17,10 @@
 
 #include "anbox/network/connection_context.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 
 ConnectionContext::ConnectionContext(
     std::function<void()> const connect_handler, Connector const* connector)
     : connect_handler(connect_handler), connector(connector) {}
 
-}  // namespace anbox
-}  // namespace network
+}

--- a/src/anbox/network/connection_context.h
+++ b/src/anbox/network/connection_context.h
@@ -22,8 +22,7 @@
 #include <functional>
 #include <memory>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class Connector;
 
 class ConnectionContext {
@@ -40,7 +39,6 @@ class ConnectionContext {
   std::function<void()> const connect_handler;
   Connector const* const connector;
 };
-}  // namespace anbox
-}  // namespace network
+}
 
 #endif

--- a/src/anbox/network/connection_creator.h
+++ b/src/anbox/network/connection_creator.h
@@ -23,8 +23,7 @@
 #include <memory>
 
 #include "anbox/do_not_copy_or_move.h"
-namespace anbox {
-namespace network {
+namespace anbox::network {
 template <typename stream_protocol>
 class ConnectionCreator : public DoNotCopyOrMove {
  public:
@@ -32,6 +31,5 @@ class ConnectionCreator : public DoNotCopyOrMove {
       std::shared_ptr<boost::asio::basic_stream_socket<stream_protocol>> const&
           socket) = 0;
 };
-}  // namespace anbox
-}  // namespace network
+}
 #endif

--- a/src/anbox/network/connections.h
+++ b/src/anbox/network/connections.h
@@ -23,8 +23,7 @@
 #include <memory>
 #include <mutex>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 template <class Connection>
 class Connections {
  public:
@@ -62,7 +61,6 @@ class Connections {
   std::mutex mutex;
   std::map<int, std::shared_ptr<Connection>> connections;
 };
-}  // namespace anbox
-}  // namespace network
+}
 
 #endif

--- a/src/anbox/network/connector.h
+++ b/src/anbox/network/connector.h
@@ -18,12 +18,9 @@
 #ifndef ANBOX_NETWORK_CONNECTOR_H
 #define ANBOX_NETWORK_CONNECTOR_H
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class Connector {
  public:
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/credentials.cpp
+++ b/src/anbox/network/credentials.cpp
@@ -17,8 +17,7 @@
 
 #include "anbox/network/credentials.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 Credentials::Credentials(pid_t pid, uid_t uid, gid_t gid)
     : pid_{pid}, uid_{uid}, gid_{gid} {}
 
@@ -27,5 +26,4 @@ pid_t Credentials::pid() const { return pid_; }
 uid_t Credentials::uid() const { return uid_; }
 
 gid_t Credentials::gid() const { return gid_; }
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/credentials.h
+++ b/src/anbox/network/credentials.h
@@ -20,8 +20,7 @@
 
 #include <sys/types.h>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class Credentials {
  public:
   Credentials(pid_t pid, uid_t uid, gid_t gid);
@@ -37,7 +36,5 @@ class Credentials {
   uid_t uid_;
   gid_t gid_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/delegate_connection_creator.h
+++ b/src/anbox/network/delegate_connection_creator.h
@@ -23,8 +23,7 @@
 
 #include <functional>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 template <typename stream_protocol>
 class DelegateConnectionCreator : public ConnectionCreator<stream_protocol> {
  public:
@@ -48,7 +47,5 @@ class DelegateConnectionCreator : public ConnectionCreator<stream_protocol> {
                      boost::asio::basic_stream_socket<stream_protocol>> const&)>
       delegate_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/delegate_message_processor.cpp
+++ b/src/anbox/network/delegate_message_processor.cpp
@@ -17,8 +17,7 @@
 
 #include "anbox/network/delegate_message_processor.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 DelegateMessageProcessor::DelegateMessageProcessor(
     std::function<bool(const std::vector<std::uint8_t> &)> process_data)
     : process_data_(process_data) {}
@@ -31,5 +30,4 @@ bool DelegateMessageProcessor::process_data(
 
   return process_data_(data);
 }
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/delegate_message_processor.h
+++ b/src/anbox/network/delegate_message_processor.h
@@ -22,8 +22,7 @@
 
 #include <functional>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class DelegateMessageProcessor : public MessageProcessor {
  public:
   DelegateMessageProcessor(
@@ -35,7 +34,5 @@ class DelegateMessageProcessor : public MessageProcessor {
  private:
   std::function<bool(const std::vector<std::uint8_t> &)> process_data_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/local_socket_messenger.cpp
+++ b/src/anbox/network/local_socket_messenger.cpp
@@ -22,8 +22,7 @@
 
 #include <boost/system/error_code.hpp>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 LocalSocketMessenger::LocalSocketMessenger(
     std::shared_ptr<boost::asio::local::stream_protocol::socket> const &socket)
     : BaseSocketMessenger(socket) {}
@@ -44,5 +43,4 @@ LocalSocketMessenger::LocalSocketMessenger(const std::string &path,
 }
 
 LocalSocketMessenger::~LocalSocketMessenger() {}
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/local_socket_messenger.h
+++ b/src/anbox/network/local_socket_messenger.h
@@ -23,8 +23,7 @@
 
 #include <boost/asio/local/stream_protocol.hpp>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class LocalSocketMessenger
     : public BaseSocketMessenger<boost::asio::local::stream_protocol> {
  public:
@@ -38,7 +37,5 @@ class LocalSocketMessenger
  private:
   std::shared_ptr<boost::asio::local::stream_protocol::socket> socket_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/message_processor.h
+++ b/src/anbox/network/message_processor.h
@@ -21,14 +21,11 @@
 #include <cstdint>
 #include <vector>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class MessageProcessor {
  public:
   virtual ~MessageProcessor() {}
   virtual bool process_data(const std::vector<std::uint8_t> &data) = 0;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/message_receiver.h
+++ b/src/anbox/network/message_receiver.h
@@ -25,8 +25,7 @@
 
 #include "anbox/common/fd.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class MessageReceiver {
  public:
   // receive message from the socket. 'handler' will be called when 'buffer' has
@@ -46,7 +45,5 @@ class MessageReceiver {
   MessageReceiver(MessageReceiver const&) = delete;
   MessageReceiver& operator=(MessageReceiver const&) = delete;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/message_sender.h
+++ b/src/anbox/network/message_sender.h
@@ -22,8 +22,7 @@
 #include <sys/types.h>
 #include <cstddef>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class MessageSender {
  public:
   virtual void send(char const* data, size_t length) = 0;
@@ -35,7 +34,6 @@ class MessageSender {
   MessageSender(MessageSender const&) = delete;
   MessageSender& operator=(MessageSender const&) = delete;
 };
-}  // namespace anbox
-}  // namespace network
+}
 
 #endif

--- a/src/anbox/network/published_socket_connector.cpp
+++ b/src/anbox/network/published_socket_connector.cpp
@@ -20,8 +20,7 @@
 #include "anbox/network/socket_helper.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 PublishedSocketConnector::PublishedSocketConnector(
     const std::string& socket_file, const std::shared_ptr<Runtime>& rt,
     const std::shared_ptr<ConnectionCreator<
@@ -54,5 +53,4 @@ void PublishedSocketConnector::on_new_connection(std::shared_ptr<boost::asio::lo
 
   start_accept();
 }
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/published_socket_connector.h
+++ b/src/anbox/network/published_socket_connector.h
@@ -26,8 +26,7 @@
 #include "anbox/network/connection_creator.h"
 #include "anbox/network/connector.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class PublishedSocketConnector : public DoNotCopyOrMove, public Connector {
  public:
   explicit PublishedSocketConnector(
@@ -50,7 +49,5 @@ class PublishedSocketConnector : public DoNotCopyOrMove, public Connector {
       connection_creator_;
   boost::asio::local::stream_protocol::acceptor acceptor_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/socket_connection.cpp
+++ b/src/anbox/network/socket_connection.cpp
@@ -33,8 +33,7 @@
 namespace ba = boost::asio;
 namespace bs = boost::system;
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 SocketConnection::SocketConnection(
     std::shared_ptr<MessageReceiver> const& message_receiver,
     std::shared_ptr<MessageSender> const& message_sender, int id_,
@@ -71,5 +70,4 @@ void SocketConnection::on_read_size(const boost::system::error_code& error, std:
   else
       connections_->remove(id());
 }
-}  // namespace anbox
-}  // namespace network
+}

--- a/src/anbox/network/socket_connection.h
+++ b/src/anbox/network/socket_connection.h
@@ -28,8 +28,7 @@
 
 #include <sys/types.h>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class SocketConnection {
  public:
   SocketConnection(
@@ -59,7 +58,6 @@ class SocketConnection {
   std::array<std::uint8_t, 8192> buffer_;
   std::string name_;
 };
-}  // namespace anbox
-}  // namespace network
+}
 
 #endif

--- a/src/anbox/network/socket_helper.cpp
+++ b/src/anbox/network/socket_helper.cpp
@@ -25,8 +25,7 @@
 
 #include <boost/exception/errinfo_errno.hpp>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 bool socket_file_exists(std::string const& filename) {
   struct stat statbuf;
   bool exists = (0 == stat(filename.c_str(), &statbuf));
@@ -72,5 +71,4 @@ std::string remove_socket_if_stale(std::string const& socket_name) {
   }
   return socket_name;
 }
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/socket_helper.h
+++ b/src/anbox/network/socket_helper.h
@@ -20,12 +20,9 @@
 
 #include <string>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 bool socket_file_exists(std::string const& filename);
 bool socket_exists(std::string const& socket_name);
 std::string remove_socket_if_stale(std::string const& socket_name);
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/socket_messenger.h
+++ b/src/anbox/network/socket_messenger.h
@@ -25,8 +25,7 @@
 #include "anbox/network/message_receiver.h"
 #include "anbox/network/message_sender.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class SocketMessenger : public MessageSender, public MessageReceiver {
  public:
   virtual Credentials creds() const = 0;
@@ -34,7 +33,5 @@ class SocketMessenger : public MessageSender, public MessageReceiver {
   virtual void set_no_delay() = 0;
   virtual void close() = 0;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/stream_socket_transport.cpp
+++ b/src/anbox/network/stream_socket_transport.cpp
@@ -30,8 +30,7 @@
 #include <boost/exception/errinfo_errno.hpp>
 #include <boost/throw_exception.hpp>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 
 StreamSocketTransport::StreamSocketTransport(const std::string& socket_path,
                                              const std::shared_ptr<Runtime>& rt)
@@ -64,5 +63,4 @@ void StreamSocketTransport::read_next_message() {
 void StreamSocketTransport::on_read_size(const boost::system::error_code& ec,
                                          std::size_t bytes_read) {}
 
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/stream_socket_transport.h
+++ b/src/anbox/network/stream_socket_transport.h
@@ -26,8 +26,7 @@
 
 #include <boost/asio.hpp>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class StreamSocketTransport {
  public:
   class Observer {
@@ -59,7 +58,5 @@ class StreamSocketTransport {
   std::shared_ptr<boost::asio::local::stream_protocol::socket> socket_;
   SocketMessenger messenger_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif  // STREAM_SOCKET_TRANSPORT_H_

--- a/src/anbox/network/tcp_socket_connector.cpp
+++ b/src/anbox/network/tcp_socket_connector.cpp
@@ -19,8 +19,7 @@
 #include "anbox/network/connection_context.h"
 #include "anbox/network/socket_helper.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 TcpSocketConnector::TcpSocketConnector(
     const boost::asio::ip::address_v4& address, unsigned short port,
     const std::shared_ptr<Runtime>& rt,
@@ -61,5 +60,4 @@ void TcpSocketConnector::on_new_connection(
 
   start_accept();
 }
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/tcp_socket_connector.h
+++ b/src/anbox/network/tcp_socket_connector.h
@@ -26,8 +26,7 @@
 #include "anbox/network/connection_creator.h"
 #include "anbox/network/connector.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class TcpSocketConnector : public DoNotCopyOrMove, public Connector {
  public:
   explicit TcpSocketConnector(
@@ -51,7 +50,5 @@ class TcpSocketConnector : public DoNotCopyOrMove, public Connector {
   std::shared_ptr<ConnectionCreator<boost::asio::ip::tcp>> connection_creator_;
   boost::asio::ip::tcp::acceptor acceptor_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/network/tcp_socket_messenger.cpp
+++ b/src/anbox/network/tcp_socket_messenger.cpp
@@ -17,8 +17,7 @@
 
 #include "anbox/network/tcp_socket_messenger.h"
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 TcpSocketMessenger::TcpSocketMessenger(const boost::asio::ip::address_v4 &addr,
                                        unsigned short port,
                                        const std::shared_ptr<Runtime> &rt) {
@@ -36,5 +35,4 @@ TcpSocketMessenger::TcpSocketMessenger(
 TcpSocketMessenger::~TcpSocketMessenger() {}
 
 unsigned short TcpSocketMessenger::local_port() const { return local_port_; }
-}  // namespace network
-}  // namespace anbox
+}

--- a/src/anbox/network/tcp_socket_messenger.h
+++ b/src/anbox/network/tcp_socket_messenger.h
@@ -23,8 +23,7 @@
 
 #include <boost/asio.hpp>
 
-namespace anbox {
-namespace network {
+namespace anbox::network {
 class TcpSocketMessenger : public BaseSocketMessenger<boost::asio::ip::tcp> {
  public:
   TcpSocketMessenger(const boost::asio::ip::address_v4 &addr,
@@ -38,7 +37,5 @@ class TcpSocketMessenger : public BaseSocketMessenger<boost::asio::ip::tcp> {
  private:
   unsigned short local_port_;
 };
-}  // namespace network
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/not_reachable.h
+++ b/src/anbox/not_reachable.h
@@ -23,8 +23,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace anbox {
-namespace util {
+namespace anbox::util {
 /// @brief NotReachable is thrown from not_reachable.
 struct NotReachable : public std::logic_error {
   /// @brief NotImplemented initializes a new instance for the given function
@@ -36,7 +35,6 @@ struct NotReachable : public std::logic_error {
 /// @brief not_reachable throws NotReachable.
 [[noreturn]] void not_reachable(const std::string& function,
                                 const std::string& file, std::uint32_t line);
-}  // namespace util
-}  // namespace anbox
+}
 
 #endif

--- a/src/anbox/platform/base_platform.cpp
+++ b/src/anbox/platform/base_platform.cpp
@@ -20,8 +20,7 @@
 #include "anbox/platform/sdl/platform.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace platform {
+namespace anbox::platform {
 std::shared_ptr<BasePlatform> create(const std::string &name,
                                      const std::shared_ptr<input::Manager> &input_manager,
                                      const Configuration &config) {
@@ -35,5 +34,4 @@ std::shared_ptr<BasePlatform> create(const std::string &name,
 
   return nullptr;
 }
-} // namespace platform
-} // namespace anbox
+}

--- a/src/anbox/platform/base_platform.h
+++ b/src/anbox/platform/base_platform.h
@@ -25,19 +25,21 @@
 
 class Renderer;
 
-namespace anbox {
-namespace audio {
-class Sink;
-class Source;
-} // namespace audio
-namespace wm {
-class Window;
-class Manager;
-} // namespace wm
-namespace input {
-class Manager;
-} // namespace input
-namespace platform {
+namespace anbox::audio {
+  class Sink;
+  class Source;
+}
+
+namespace anbox::wm {
+  class Window;
+  class Manager;
+}
+
+namespace anbox::input {
+  class Manager;
+}
+
+namespace anbox::platform {
 class BasePlatform {
  public:
   virtual ~BasePlatform() {}
@@ -70,7 +72,5 @@ struct Configuration {
 std::shared_ptr<BasePlatform> create(const std::string &name,
                                      const std::shared_ptr<input::Manager> &input_manager,
                                      const Configuration &config);
-}  // namespace platform
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/platform/sdl/audio_sink.cpp
+++ b/src/anbox/platform/sdl/audio_sink.cpp
@@ -26,9 +26,7 @@ namespace {
 const constexpr size_t max_queue_size{16};
 }
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 AudioSink::AudioSink() :
   device_id_(0),
   queue_(max_queue_size) {
@@ -114,6 +112,4 @@ void AudioSink::write_data(const std::vector<std::uint8_t> &data) {
   graphics::Buffer buffer{data.data(), data.data() + data.size()};
   queue_.push_locked(std::move(buffer), l);
 }
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
+}

--- a/src/anbox/platform/sdl/audio_sink.h
+++ b/src/anbox/platform/sdl/audio_sink.h
@@ -24,9 +24,7 @@
 
 #include <thread>
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 class AudioSink : public audio::Sink {
  public:
   AudioSink();
@@ -48,8 +46,5 @@ class AudioSink : public audio::Sink {
   graphics::Buffer read_buffer_;
   size_t read_buffer_left_ = 0;
 };
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/platform/sdl/keycode_converter.cpp
+++ b/src/anbox/platform/sdl/keycode_converter.cpp
@@ -21,9 +21,7 @@
 
 #include <linux/input.h>
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 std::uint16_t KeycodeConverter::convert(const SDL_Scancode &scan_code) {
   for (std::uint16_t n = 0; n < code_map.size(); n++) {
     if (code_map[n] == scan_code) return n;
@@ -290,6 +288,4 @@ const std::array<SDL_Scancode, 249> KeycodeConverter::code_map = {{
                              */
     SDL_SCANCODE_UNKNOWN         /*  KEY_MICMUTE     248 Mute / unmute the microphone */
 }};
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
+}

--- a/src/anbox/platform/sdl/keycode_converter.h
+++ b/src/anbox/platform/sdl/keycode_converter.h
@@ -24,9 +24,7 @@
 
 #include <array>
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 class KeycodeConverter {
  public:
   static std::uint16_t convert(const SDL_Scancode &scan_code);
@@ -34,8 +32,5 @@ class KeycodeConverter {
  private:
   static const std::array<SDL_Scancode, 249> code_map;
 };
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/platform/sdl/mir_display_connection.cpp
+++ b/src/anbox/platform/sdl/mir_display_connection.cpp
@@ -42,8 +42,7 @@ static const MirDisplayOutput *find_active_output(
 }
 }
 
-namespace anbox {
-namespace sdl {
+namespace anbox::sdl {
 MirDisplayConnection::MirDisplayConnection()
     : connection_(nullptr),
       output_id_(-1),
@@ -119,5 +118,4 @@ int MirDisplayConnection::vertical_resolution() const {
 int MirDisplayConnection::horizontal_resolution() const {
   return horizontal_resolution_;
 }
-}  // namespace sdl
-}  // namespace anbox
+}

--- a/src/anbox/platform/sdl/mir_display_connection.h
+++ b/src/anbox/platform/sdl/mir_display_connection.h
@@ -24,8 +24,7 @@
 
 #include <EGL/egl.h>
 
-namespace anbox {
-namespace sdl {
+namespace anbox::sdl {
 class MirDisplayConnection {
  public:
   MirDisplayConnection();
@@ -46,7 +45,5 @@ class MirDisplayConnection {
   int vertical_resolution_;
   int horizontal_resolution_;
 };
-}  // namespace sdl
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/platform/sdl/platform.cpp
+++ b/src/anbox/platform/sdl/platform.cpp
@@ -32,9 +32,7 @@
 #include <sys/types.h>
 #pragma GCC diagnostic pop
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 Platform::Platform(
     const std::shared_ptr<input::Manager> &input_manager,
     const Configuration &config)
@@ -514,6 +512,4 @@ std::shared_ptr<audio::Source> Platform::create_audio_source() {
 bool Platform::supports_multi_window() const {
   return true;
 }
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
+}

--- a/src/anbox/platform/sdl/platform.h
+++ b/src/anbox/platform/sdl/platform.h
@@ -29,16 +29,16 @@
 
 class Renderer;
 
-namespace anbox {
-namespace input {
-class Device;
-class Manager;
-}  // namespace input
-namespace wm {
-class Manager;
-} // namespace wm
-namespace platform {
-namespace sdl {
+namespace anbox::input {
+  class Device;
+  class Manager;
+}
+
+namespace anbox::wm {
+  class Manager;
+}
+
+namespace anbox::platform::sdl {
 class Platform : public std::enable_shared_from_this<Platform>,
                        public platform::BasePlatform,
                        public Window::Observer {
@@ -110,8 +110,5 @@ class Platform : public std::enable_shared_from_this<Platform>,
   void push_finger_up(int finger_id, std::vector<input::Event> &touch_events);
   void push_finger_motion(int x, int y, int finger_id, std::vector<input::Event> &touch_events);
 };
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/platform/sdl/window.cpp
+++ b/src/anbox/platform/sdl/window.cpp
@@ -34,9 +34,7 @@ constexpr const int button_margin{5};
 constexpr const int button_padding{0};
 }
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 Window::Id Window::Invalid{-1};
 
 Window::Observer::~Observer() {}
@@ -220,6 +218,4 @@ EGLNativeWindowType Window::native_handle() const { return native_window_; }
 Window::Id Window::id() const { return id_; }
 
 std::uint32_t Window::window_id() const { return SDL_GetWindowID(window_); }
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
+}

--- a/src/anbox/platform/sdl/window.h
+++ b/src/anbox/platform/sdl/window.h
@@ -28,9 +28,7 @@
 
 class Renderer;
 
-namespace anbox {
-namespace platform {
-namespace sdl {
+namespace anbox::platform::sdl {
 class Window : public std::enable_shared_from_this<Window>, public wm::Window {
  public:
   typedef std::int32_t Id;
@@ -74,8 +72,5 @@ class Window : public std::enable_shared_from_this<Window>, public wm::Window {
   EGLNativeWindowType native_window_;
   SDL_Window *window_;
 };
-} // namespace sdl
-} // namespace platform
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/qemu/adb_message_processor.cpp
+++ b/src/anbox/qemu/adb_message_processor.cpp
@@ -43,8 +43,7 @@ const boost::posix_time::seconds default_adb_wait_time{1};
 
 using namespace std::placeholders;
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 std::mutex AdbMessageProcessor::active_instance_{};
 
 AdbMessageProcessor::AdbMessageProcessor(
@@ -206,5 +205,4 @@ bool AdbMessageProcessor::process_data(const std::vector<std::uint8_t> &data) {
 
   return true;
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/at_parser.cpp
+++ b/src/anbox/qemu/at_parser.cpp
@@ -19,8 +19,7 @@
 #include "anbox/logger.h"
 #include "anbox/utils.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 AtParser::AtParser() {}
 
 void AtParser::register_command(const std::string &command,
@@ -72,5 +71,4 @@ void AtParser::processs_command(const std::string &command) {
 
   handler(real_command);
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/at_parser.h
+++ b/src/anbox/qemu/at_parser.h
@@ -26,8 +26,7 @@
 
 #include "anbox/do_not_copy_or_move.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 class AtParser {
  public:
   typedef std::function<void(const std::string &)> CommandHandler;
@@ -43,7 +42,5 @@ class AtParser {
 
   std::map<std::string, CommandHandler> handlers_;
 };
-}  // namespace qemu
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/qemu/boot_properties_message_processor.cpp
+++ b/src/anbox/qemu/boot_properties_message_processor.cpp
@@ -19,8 +19,7 @@
 #include "anbox/graphics/density.h"
 #include "anbox/utils.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 BootPropertiesMessageProcessor::BootPropertiesMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger)
     : QemudMessageProcessor(messenger) {}
@@ -46,5 +45,4 @@ void BootPropertiesMessageProcessor::list_properties() {
 
   finish_message();
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/bootanimation_message_processor.cpp
+++ b/src/anbox/qemu/bootanimation_message_processor.cpp
@@ -20,8 +20,7 @@
 
 #include <fstream>
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 BootAnimationMessageProcessor::BootAnimationMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger,
     const std::string &icon_path)
@@ -44,5 +43,4 @@ void BootAnimationMessageProcessor::retrieve_icon() {
   }
 }
 
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/camera_message_processor.cpp
+++ b/src/anbox/qemu/camera_message_processor.cpp
@@ -18,8 +18,7 @@
 #include "anbox/qemu/camera_message_processor.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 CameraMessageProcessor::CameraMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger)
     : messenger_(messenger) {}
@@ -60,5 +59,4 @@ void CameraMessageProcessor::list() {
   snprintf(buf, 5, "\n");
   messenger_->send(buf, strlen(buf));
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/fingerprint_message_processor.cpp
+++ b/src/anbox/qemu/fingerprint_message_processor.cpp
@@ -18,8 +18,7 @@
 #include "anbox/qemu/fingerprint_message_processor.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 FingerprintMessageProcessor::FingerprintMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger)
     : QemudMessageProcessor(messenger) {}
@@ -37,5 +36,4 @@ void FingerprintMessageProcessor::listen() {
   messenger_->send(buf, strlen(buf));
   finish_message();
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/gps_message_processor.cpp
+++ b/src/anbox/qemu/gps_message_processor.cpp
@@ -21,8 +21,7 @@
 
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 GpsMessageProcessor::GpsMessageProcessor(const std::shared_ptr<network::SocketMessenger> &messenger, const std::shared_ptr<anbox::application::GpsInfoBroker> &gpsInfoBroker) : messenger_(messenger), gps_info_broker_(gpsInfoBroker) {
   connection_ = gps_info_broker_->newNmeaSentence.connect([this](const std::string &sentence) {
     auto dataToSend = sentence + "\n";
@@ -38,5 +37,4 @@ bool GpsMessageProcessor::process_data(const std::vector<std::uint8_t> &data) {
   ERROR("Got unexpected GPS data: " + std::to_string(data.size()));
   return true;
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/gps_message_processor.h
+++ b/src/anbox/qemu/gps_message_processor.h
@@ -22,8 +22,7 @@
 #include "anbox/network/message_processor.h"
 #include "anbox/network/socket_messenger.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 class GpsMessageProcessor : public network::MessageProcessor {
  public:
   GpsMessageProcessor(const std::shared_ptr<network::SocketMessenger> &messenger, const std::shared_ptr<anbox::application::GpsInfoBroker> &gpsInfoBroker);
@@ -36,7 +35,5 @@ class GpsMessageProcessor : public network::MessageProcessor {
   std::shared_ptr<anbox::application::GpsInfoBroker> gps_info_broker_;
   boost::signals2::connection connection_;
 };
-}  // namespace qemu
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/qemu/gsm_message_processor.cpp
+++ b/src/anbox/qemu/gsm_message_processor.cpp
@@ -24,8 +24,7 @@
 
 using namespace std::placeholders;
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 GsmMessageProcessor::GsmMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger)
     : messenger_(messenger), parser_(std::make_shared<AtParser>()) {
@@ -108,5 +107,4 @@ void GsmMessageProcessor::handle_cfun(const std::string &command) {
   else if (utils::string_starts_with(command, "+CFUN="))
     send_reply("");
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/hwcontrol_message_processor.cpp
+++ b/src/anbox/qemu/hwcontrol_message_processor.cpp
@@ -18,8 +18,7 @@
 #include "anbox/qemu/hwcontrol_message_processor.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 HwControlMessageProcessor::HwControlMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger)
     : QemudMessageProcessor(messenger) {}
@@ -40,5 +39,4 @@ void HwControlMessageProcessor::handle_command(const std::string &command) {
   (void)command;
 #endif
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/null_message_processor.cpp
+++ b/src/anbox/qemu/null_message_processor.cpp
@@ -21,8 +21,7 @@
 
 #include <string.h>
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 NullMessageProcessor::NullMessageProcessor() {}
 
 NullMessageProcessor::~NullMessageProcessor() {}
@@ -31,5 +30,4 @@ bool NullMessageProcessor::process_data(const std::vector<std::uint8_t> &data) {
   (void)data;
   return true;
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/pipe_connection_creator.cpp
+++ b/src/anbox/qemu/pipe_connection_creator.cpp
@@ -66,8 +66,7 @@ std::string client_type_to_string(
   return "unknown";
 }
 }
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 PipeConnectionCreator::PipeConnectionCreator(std::shared_ptr<Renderer> renderer, std::shared_ptr<Runtime> rt, std::shared_ptr<anbox::application::SensorsState> sensors_state, std::shared_ptr<anbox::application::GpsInfoBroker> gpsInfoBroker)
     : renderer_(renderer),
       runtime_(rt),
@@ -172,5 +171,4 @@ PipeConnectionCreator::create_processor(
 int PipeConnectionCreator::next_id() {
   return next_connection_id_.fetch_add(1);
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/pipe_connection_creator.h
+++ b/src/anbox/qemu/pipe_connection_creator.h
@@ -33,8 +33,7 @@
 
 class Renderer;
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 class PipeConnectionCreator
     : public network::ConnectionCreator<boost::asio::local::stream_protocol> {
  public:
@@ -75,7 +74,5 @@ class PipeConnectionCreator
   std::atomic<int> next_connection_id_;
   std::shared_ptr<network::Connections<network::SocketConnection>> const connections_;
 };
-}  // namespace qemu
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/qemu/qemud_message_processor.cpp
+++ b/src/anbox/qemu/qemud_message_processor.cpp
@@ -25,8 +25,7 @@ namespace {
 static constexpr const long header_size{4};
 } // namespace
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 QemudMessageProcessor::QemudMessageProcessor(
     const std::shared_ptr<network::SocketMessenger> &messenger)
     : messenger_(messenger) {}
@@ -86,5 +85,4 @@ void QemudMessageProcessor::finish_message() {
   // Send terminating NULL byte
   messenger_->send(static_cast<const char *>(""), 1);
 }
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/sensors_message_processor.cpp
+++ b/src/anbox/qemu/sensors_message_processor.cpp
@@ -36,8 +36,8 @@ std::ostream& operator<<(std::ostream& os, std::tuple<double, double, double> t)
 }
 }  // namespace std
 
-namespace anbox {
-namespace qemu {
+
+namespace anbox::qemu {
 SensorsMessageProcessor::SensorsMessageProcessor(
     shared_ptr<network::SocketMessenger> messenger, shared_ptr<application::SensorsState> sensorsState)
     : QemudMessageProcessor(messenger), sensors_state_(sensorsState) {
@@ -113,5 +113,4 @@ void SensorsMessageProcessor::send_message(const string& msg) {
   messenger_->send(msg.c_str(), msg.length());
 }
 
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/sensors_message_processor.h
+++ b/src/anbox/qemu/sensors_message_processor.h
@@ -23,8 +23,7 @@
 #include "anbox/application/sensors_state.h"
 #include "anbox/qemu/qemud_message_processor.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 class SensorsMessageProcessor : public QemudMessageProcessor {
  public:
   SensorsMessageProcessor(
@@ -42,7 +41,5 @@ class SensorsMessageProcessor : public QemudMessageProcessor {
   std::atomic<bool> run_thread_ = true;
   std::thread thread_;
 };
-}  // namespace qemu
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/qemu/telephony_manager.cpp
+++ b/src/anbox/qemu/telephony_manager.cpp
@@ -19,8 +19,7 @@
 #include "anbox/dbus/ofono.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 TelephonyManager::TelephonyManager(const core::dbus::Bus::Ptr &bus)
     : bus_(bus) {
   ofono_ = core::dbus::Service::use_service(bus_, "org.ofono");
@@ -36,5 +35,4 @@ TelephonyManager::TelephonyManager(const core::dbus::Bus::Ptr &bus)
 }
 
 TelephonyManager::~TelephonyManager() {}
-}  // namespace qemu
-}  // namespace anbox
+}

--- a/src/anbox/qemu/telephony_manager.h
+++ b/src/anbox/qemu/telephony_manager.h
@@ -22,8 +22,7 @@
 #include <core/dbus/object.h>
 #include <core/dbus/service.h>
 
-namespace anbox {
-namespace qemu {
+namespace anbox::qemu {
 class TelephonyManager {
  public:
   TelephonyManager(const core::dbus::Bus::Ptr &bus);
@@ -34,7 +33,5 @@ class TelephonyManager {
   core::dbus::Service::Ptr ofono_;
   core::dbus::Object::Ptr modem_;
 };
-}  // namespace qemu
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/rpc/channel.cpp
+++ b/src/anbox/rpc/channel.cpp
@@ -25,8 +25,7 @@
 
 #include "anbox_rpc.pb.h"
 
-namespace anbox {
-namespace rpc {
+namespace anbox::rpc {
 Channel::Channel(const std::shared_ptr<PendingCallCache> &pending_calls,
                  const std::shared_ptr<network::MessageSender> &sender)
     : pending_calls_(pending_calls), sender_(sender) {}
@@ -100,5 +99,4 @@ std::uint32_t Channel::next_id() {
   static std::uint32_t next_message_id = 0;
   return next_message_id++;
 }
-}  // namespace rpc
-}  // namespace anbox
+}

--- a/src/anbox/rpc/channel.h
+++ b/src/anbox/rpc/channel.h
@@ -22,23 +22,18 @@
 #include <memory>
 #include <mutex>
 
-namespace google {
-namespace protobuf {
-class Closure;
-class MessageLite;
-}  // namespace protobuf
-}  // namespace google
+namespace google::protobuf {
+  class Closure;
+  class MessageLite;
+}
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Invocation;
-}  // namespace rpc
-}  // namespace protobuf
-namespace network {
-class MessageSender;
-}  // namespace network
-namespace rpc {
+namespace anbox::protobuf::rpc {
+  class Invocation;  
+}
+namespace anbox::network {
+  class MessageSender;
+}
+namespace anbox::rpc {
 class PendingCallCache;
 class Channel {
  public:
@@ -66,7 +61,6 @@ class Channel {
   std::shared_ptr<network::MessageSender> sender_;
   std::mutex write_mutex_;
 };
-}  // namespace rpc
-}  // namespace anbox
+}
 
 #endif

--- a/src/anbox/rpc/connection_creator.cpp
+++ b/src/anbox/rpc/connection_creator.cpp
@@ -24,8 +24,7 @@
 
 namespace ba = boost::asio;
 
-namespace anbox {
-namespace rpc {
+namespace anbox::rpc {
 ConnectionCreator::ConnectionCreator(const std::shared_ptr<Runtime>& rt,
                                      const MessageProcessorFactory& factory)
     : runtime_(rt),
@@ -60,5 +59,4 @@ void ConnectionCreator::create_connection_for(
 
 int ConnectionCreator::next_id() { return next_connection_id_.fetch_add(1); }
 
-}  // namespace rpc
-}  // namespace anbox
+}

--- a/src/anbox/rpc/connection_creator.h
+++ b/src/anbox/rpc/connection_creator.h
@@ -29,8 +29,7 @@
 #include "anbox/network/socket_messenger.h"
 #include "anbox/runtime.h"
 
-namespace anbox {
-namespace rpc {
+namespace anbox::rpc {
 class ConnectionCreator
     : public network::ConnectionCreator<boost::asio::local::stream_protocol> {
  public:
@@ -55,7 +54,5 @@ class ConnectionCreator
       connections_;
   MessageProcessorFactory message_processor_factory_;
 };
-}  // namespace rpc
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/rpc/make_protobuf_object.h
+++ b/src/anbox/rpc/make_protobuf_object.h
@@ -21,8 +21,7 @@
 
 #include <memory>
 
-namespace anbox {
-namespace rpc {
+namespace anbox::rpc {
 template <typename ProtobufType>
 auto make_protobuf_object() {
   return std::unique_ptr<ProtobufType>{ProtobufType::default_instance().New()};
@@ -34,7 +33,5 @@ auto make_protobuf_object(ProtobufType const& from) {
   object->CopyFrom(from);
   return object;
 }
-}  // namespace rpc
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/rpc/message_processor.h
+++ b/src/anbox/rpc/message_processor.h
@@ -27,13 +27,11 @@
 #include <google/protobuf/message_lite.h>
 #include <google/protobuf/stubs/common.h>
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Invocation;
-}  // namespace rpc
-}  // namespace protobuf
-namespace rpc {
+namespace anbox::protobuf::rpc {
+  class Invocation;
+}
+
+namespace anbox::rpc {
 class Invocation {
  public:
   Invocation(anbox::protobuf::rpc::Invocation const& invocation)
@@ -66,7 +64,5 @@ class MessageProcessor : public network::MessageProcessor {
   std::vector<std::uint8_t> buffer_;
   std::shared_ptr<PendingCallCache> pending_calls_;
 };
-}  // namespace rpc
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/rpc/pending_call_cache.cpp
+++ b/src/anbox/rpc/pending_call_cache.cpp
@@ -24,8 +24,7 @@
 #include <google/protobuf/stubs/callback.h>
 #endif
 
-namespace anbox {
-namespace rpc {
+namespace anbox::rpc {
 PendingCallCache::PendingCallCache() {}
 
 void PendingCallCache::save_completion_details(
@@ -72,5 +71,4 @@ bool PendingCallCache::empty() const {
   std::unique_lock<std::mutex> lock(mutex_);
   return pending_calls_.empty();
 }
-}  // namespace rpc
-}  // namespace anbox
+}

--- a/src/anbox/rpc/pending_call_cache.h
+++ b/src/anbox/rpc/pending_call_cache.h
@@ -23,21 +23,17 @@
 #include <map>
 #include <mutex>
 
-namespace google {
-namespace protobuf {
-class Closure;
-class MessageLite;
-}  // namespace protobuf
-}  // namespace google
+namespace google::protobuf {
+  class Closure;
+  class MessageLite;
+}
 
-namespace anbox {
-namespace protobuf {
-namespace rpc {
-class Invocation;
-class Result;
-}  // namespace rpc
-}  // namespace protobuf
-namespace rpc {
+namespace anbox::protobuf::rpc {
+  class Invocation;
+  class Result;
+}
+
+namespace anbox::rpc {
 class PendingCallCache {
  public:
   PendingCallCache();
@@ -68,7 +64,6 @@ class PendingCallCache {
   std::mutex mutable mutex_;
   std::map<int, PendingCall> pending_calls_;
 };
-}  // namespace rpc
-}  // namespace anbox
+}
 
 #endif

--- a/src/anbox/rpc/template_message_processor.h
+++ b/src/anbox/rpc/template_message_processor.h
@@ -28,8 +28,7 @@
 
 #include "anbox_rpc.pb.h"
 
-namespace anbox {
-namespace rpc {
+namespace anbox::rpc {
 // Utility metafunction result_ptr_t<> allows invoke() to pick the right
 // send_response() overload. The base template resolves to the prototype
 // "send_response(::google::protobuf::uint32 id, ::google::protobuf::Message*
@@ -69,7 +68,5 @@ void invoke(Self* self, Bridge* rpc,
     self->send_response(invocation.id(), &result_message);
   }
 }
-}  // namespace rpc
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/testing/gtest_utils.h
+++ b/src/anbox/testing/gtest_utils.h
@@ -22,8 +22,7 @@
 // Miscellenaous helper declarations for unit-tests using the GoogleTest
 // framework.
 
-namespace anbox {
-namespace testing {
+namespace anbox::testing {
 // RangesMatch is a useful template used to compare the content of two
 // ranges at runtime. Usage is simply:
 //
@@ -58,5 +57,4 @@ inline ::testing::AssertionResult RangesMatch(const Range1& expected,
 
   return ::testing::AssertionSuccess();
 }
-}  // namespace testing
-}  // namespace anbox
+}

--- a/src/anbox/ui/splash_screen.cpp
+++ b/src/anbox/ui/splash_screen.cpp
@@ -22,8 +22,7 @@
 
 #include <SDL2/SDL_image.h>
 
-namespace anbox {
-namespace ui {
+namespace anbox::ui {
 SplashScreen::SplashScreen() {
 #ifdef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
   // Don't disable compositing
@@ -99,5 +98,4 @@ void SplashScreen::process_events() {
     }
   }
 }
-} // namespace ui
-} // namespace anbox
+}

--- a/src/anbox/ui/splash_screen.h
+++ b/src/anbox/ui/splash_screen.h
@@ -22,8 +22,7 @@
 
 #include <SDL2/SDL.h>
 
-namespace anbox {
-namespace ui {
+namespace anbox::ui {
 class SplashScreen {
  public:
   SplashScreen();
@@ -36,7 +35,5 @@ class SplashScreen {
   bool event_thread_running_;
   SDL_Window *window_;
 };
-} // namespace ui
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/utils.cpp
+++ b/src/anbox/utils.cpp
@@ -34,8 +34,7 @@
 
 namespace fs = boost::filesystem;
 
-namespace anbox {
-namespace utils {
+namespace anbox::utils {
 std::vector<std::string> collect_arguments(int argc, char **argv) {
   std::vector<std::string> result;
   for (int i = 1; i < argc; i++) result.push_back(argv[i]);
@@ -205,5 +204,4 @@ std::string find_program_on_path(const std::string &name) {
   }
   return "";
 }
-}  // namespace utils
-}  // namespace anbox
+}

--- a/src/anbox/utils.h
+++ b/src/anbox/utils.h
@@ -23,8 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace anbox {
-namespace utils {
+namespace anbox::utils {
 
 std::vector<std::string> collect_arguments(int argc, char **argv);
 
@@ -60,8 +59,7 @@ std::string find_program_on_path(const std::string &name);
 
 template <typename... Types>
 static std::string string_format(const std::string &fmt_str, Types &&... args);
-}  // namespace utils
-}  // namespace anbox
+}
 
 namespace impl {
 // Base case, just return the passed in boost::format instance.

--- a/src/anbox/utils/environment_file.cpp
+++ b/src/anbox/utils/environment_file.cpp
@@ -20,8 +20,7 @@
 
 #include <fstream>
 
-namespace anbox {
-namespace utils {
+namespace anbox::utils {
 EnvironmentFile::EnvironmentFile(const boost::filesystem::path &path) {
   std::ifstream in(path.string());
   std::string line;
@@ -39,5 +38,4 @@ std::string EnvironmentFile::value(const std::string &key, const std::string &de
     return default_value;
   return iter->second;
 }
-} // namespace utils
-} // namespace anbox
+}

--- a/src/anbox/utils/environment_file.h
+++ b/src/anbox/utils/environment_file.h
@@ -22,8 +22,7 @@
 #include <string>
 #include <boost/filesystem.hpp>
 
-namespace anbox {
-namespace utils {
+namespace anbox::utils {
 class EnvironmentFile {
  public:
   EnvironmentFile(const boost::filesystem::path &path);
@@ -34,7 +33,5 @@ class EnvironmentFile {
  private:
   std::map<std::string, std::string> data_;
 };
-} // namespace utils
-} // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/display.cpp
+++ b/src/anbox/wm/display.cpp
@@ -17,9 +17,7 @@
 
 #include "anbox/wm/display.h"
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 Display::Id Display::Invalid = -1;
 Display::Id Display::Default = 0;
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/display.h
+++ b/src/anbox/wm/display.h
@@ -20,8 +20,7 @@
 
 #include <cstdint>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 class Display {
  public:
   typedef std::int32_t Id;
@@ -32,7 +31,5 @@ class Display {
   Display() = delete;
   Display(const Display&) = delete;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/manager.cpp
+++ b/src/anbox/wm/manager.cpp
@@ -17,8 +17,6 @@
 
 #include "anbox/wm/manager.h"
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 Manager::~Manager() {}
-} // namespace wm
-} // namespace anbox
+}

--- a/src/anbox/wm/manager.h
+++ b/src/anbox/wm/manager.h
@@ -25,8 +25,7 @@
 #include <memory>
 #include <mutex>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 class Manager {
  public:
   virtual ~Manager();
@@ -43,7 +42,5 @@ class Manager {
   // FIXME only applies for the multi-window case
   virtual std::shared_ptr<Window> find_window_for_task(const Task::Id &task) = 0;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/multi_window_manager.cpp
+++ b/src/anbox/wm/multi_window_manager.cpp
@@ -23,8 +23,7 @@
 
 #include <algorithm>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 MultiWindowManager::MultiWindowManager(const std::weak_ptr<platform::BasePlatform> &platform,
                                        const std::shared_ptr<bridge::AndroidApiStub> &android_api_stub,
                                        const std::shared_ptr<application::Database> &app_db)
@@ -124,5 +123,4 @@ void MultiWindowManager::set_focused_task(const Task::Id &task) {
 void MultiWindowManager::remove_task(const Task::Id &task) {
   android_api_stub_->remove_task(task);
 }
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/multi_window_manager.h
+++ b/src/anbox/wm/multi_window_manager.h
@@ -24,17 +24,19 @@
 #include <memory>
 #include <mutex>
 
-namespace anbox {
-namespace application {
-class Database;
-} // namespace application
-namespace bridge {
-class AndroidApiStub;
-} // namespace bridge
-namespace platform {
-class BasePlatform;
-} // namespace platform
-namespace wm {
+namespace anbox::application {
+  class Database;
+}
+
+namespace anbox::bridge {
+  class AndroidApiStub;
+}
+
+namespace anbox::platform {
+  class BasePlatform;
+}
+
+namespace anbox::wm {
 class MultiWindowManager : public Manager {
  public:
   MultiWindowManager(const std::weak_ptr<platform::BasePlatform> &platform,
@@ -58,7 +60,5 @@ class MultiWindowManager : public Manager {
   std::shared_ptr<application::Database> app_db_;
   std::map<Task::Id, std::shared_ptr<Window>> windows_;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/single_window_manager.cpp
+++ b/src/anbox/wm/single_window_manager.cpp
@@ -24,8 +24,7 @@
 #include <sys/types.h>
 #include <signal.h>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 SingleWindowManager::SingleWindowManager(const std::weak_ptr<platform::BasePlatform> &platform,
                                          const graphics::Rect &window_size,
                                          const std::shared_ptr<application::Database> &app_db)
@@ -75,5 +74,4 @@ void SingleWindowManager::remove_task(const Task::Id &task) {
   // application.
   kill(getpid(), SIGTERM);
 }
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/single_window_manager.h
+++ b/src/anbox/wm/single_window_manager.h
@@ -24,14 +24,15 @@
 #include <memory>
 #include <mutex>
 
-namespace anbox {
-namespace application {
+namespace anbox::application {
 class Database;
-} // namespace application
-namespace platform {
+}
+
+namespace anbox::platform {
 class BasePlatform;
-} // namespace platform
-namespace wm {
+}
+
+namespace anbox::wm {
 class Window;
 class SingleWindowManager : public Manager {
  public:
@@ -57,7 +58,5 @@ class SingleWindowManager : public Manager {
   std::shared_ptr<application::Database> app_db_;
   std::shared_ptr<Window> window_;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/stack.cpp
+++ b/src/anbox/wm/stack.cpp
@@ -17,8 +17,7 @@
 
 #include "anbox/wm/stack.h"
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 std::ostream &operator<<(std::ostream &out, const Stack::Id &stack) {
   switch (stack) {
   case anbox::wm::Stack::Id::Default:
@@ -47,5 +46,4 @@ std::istream& operator>>(std::istream& in, Stack::Id &stack) {
     stack = anbox::wm::Stack::Id::Freeform;
   return in;
 }
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/stack.h
+++ b/src/anbox/wm/stack.h
@@ -20,8 +20,7 @@
 
 #include <ostream>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 class Stack {
  public:
   enum class Id {
@@ -37,9 +36,7 @@ class Stack {
 
 std::ostream& operator<<(std::ostream &out, Stack::Id const &stack);
 std::istream& operator>>(std::istream &in, Stack::Id &stack);
-}  // namespace wm
-}  // namespace anbox
-
+}
 
 
 #endif

--- a/src/anbox/wm/task.cpp
+++ b/src/anbox/wm/task.cpp
@@ -17,8 +17,6 @@
 
 #include "anbox/wm/task.h"
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 Task::Id Task::Invalid = -1;
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/task.h
+++ b/src/anbox/wm/task.h
@@ -20,8 +20,7 @@
 
 #include <cstdint>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 class Task {
  public:
   typedef std::int32_t Id;
@@ -31,7 +30,5 @@ class Task {
   Task() = delete;
   Task(const Task&) = delete;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/window.cpp
+++ b/src/anbox/wm/window.cpp
@@ -19,8 +19,7 @@
 #include "anbox/graphics/emugl/Renderer.h"
 #include "anbox/logger.h"
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 Window::Window(const std::shared_ptr<Renderer> &renderer, const Task::Id &task, const graphics::Rect &frame, const std::string &title)
     : renderer_(renderer), task_(task), frame_(frame), title_(title) {}
 
@@ -58,5 +57,4 @@ void Window::release() {
     return;
   renderer_->destroyNativeWindow(native_handle());
 }
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/window.h
+++ b/src/anbox/wm/window.h
@@ -29,8 +29,7 @@
 
 class Renderer;
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 // FIXME(morphis): move this somewhere else once we have the integration
 // with the emugl layer.
 class Layer {
@@ -66,7 +65,5 @@ class Window {
   std::string title_;
   bool attached_ = false;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif

--- a/src/anbox/wm/window_state.cpp
+++ b/src/anbox/wm/window_state.cpp
@@ -17,8 +17,7 @@
 
 #include "anbox/wm/window_state.h"
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 WindowState::WindowState()
     : display_(Display::Invalid),
       has_surface_(false),
@@ -39,5 +38,4 @@ WindowState::WindowState(const Display::Id &display, bool has_surface,
       stack_(stack) {}
 
 WindowState::~WindowState() {}
-}  // namespace wm
-}  // namespace anbox
+}

--- a/src/anbox/wm/window_state.h
+++ b/src/anbox/wm/window_state.h
@@ -26,8 +26,7 @@
 #include <string>
 #include <vector>
 
-namespace anbox {
-namespace wm {
+namespace anbox::wm {
 class WindowState {
  public:
   typedef std::vector<WindowState> List;
@@ -53,7 +52,5 @@ class WindowState {
   Task::Id task_;
   Stack::Id stack_;
 };
-}  // namespace wm
-}  // namespace anbox
-
+}
 #endif


### PR DESCRIPTION
C++17 introduced nested namespaces to reduce declaration footprint.
From:
```
namespace first {
    namespace second { 
        ... 
    }
}
```
To:
```
namespace first::second {
    ...
}
```
A simple syntax change that improves readability.
This refactoring is related to upcoming experiments regarding [C++20 modules](https://en.cppreference.com/w/cpp/language/modules).

Since the semantics have not been changed, I would argue that copyright headers in code files are still valid.

Somehow the googletest submodule was able to sneak into this branch. This PR is still up for discussion anyway, so I would wait until submodule PR is merged and then figure out an appropriate fix for that.