### PR TITLE
remove PendingCallCache from ManagementApiSkeleton

### DIFF
--- a/src/anbox/container/management_api_skeleton.cpp
+++ b/src/anbox/container/management_api_skeleton.cpp
@@ -32,9 +32,8 @@
 namespace anbox {
 namespace container {
 ManagementApiSkeleton::ManagementApiSkeleton(
-    const std::shared_ptr<rpc::PendingCallCache> &pending_calls,
     const std::shared_ptr<Container> &container)
-    : pending_calls_(pending_calls), container_(container) {}
+    : container_(container) { }
 
 ManagementApiSkeleton::~ManagementApiSkeleton() {}
 

--- a/src/anbox/container/management_api_skeleton.h
+++ b/src/anbox/container/management_api_skeleton.h
@@ -44,7 +44,6 @@ class Container;
 class ManagementApiSkeleton {
  public:
   ManagementApiSkeleton(
-      const std::shared_ptr<rpc::PendingCallCache> &pending_calls,
       const std::shared_ptr<Container> &container);
   ~ManagementApiSkeleton();
 
@@ -57,7 +56,6 @@ class ManagementApiSkeleton {
       anbox::protobuf::rpc::Void *response, google::protobuf::Closure *done);
 
  private:
-  std::shared_ptr<rpc::PendingCallCache> pending_calls_;
   std::shared_ptr<Container> container_;
 };
 }  // namespace container

--- a/src/anbox/container/service.cpp
+++ b/src/anbox/container/service.cpp
@@ -86,7 +86,7 @@ void Service::new_client(std::shared_ptr<boost::asio::local::stream_protocol::so
   auto pending_calls = std::make_shared<rpc::PendingCallCache>();
   auto rpc_channel = std::make_shared<rpc::Channel>(pending_calls, messenger);
   auto server = std::make_shared<container::ManagementApiSkeleton>(
-      pending_calls, std::make_shared<LxcContainer>(config_.privileged,
+      std::make_shared<LxcContainer>(config_.privileged,
                                                     config_.rootfs_overlay,
                                                     config_.container_network_address,
                                                     config_.container_network_gateway,


### PR DESCRIPTION
PendingCallCache was a ctor param of ManagementApiSkeleton, but was not used apart from setting the private member.

