### PR TITLE
remove unused parameter Runtime

### DIFF
--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -248,7 +248,7 @@ anbox::cmds::SessionManager::SessionManager()
     auto bridge_connector = std::make_shared<network::PublishedSocketConnector>(
         utils::string_format("%s/anbox_bridge", socket_path), rt,
         std::make_shared<rpc::ConnectionCreator>(
-            rt, [&](const std::shared_ptr<network::MessageSender> &sender) {
+            [&](const std::shared_ptr<network::MessageSender> &sender) {
               auto pending_calls = std::make_shared<rpc::PendingCallCache>();
               auto rpc_channel =
                   std::make_shared<rpc::Channel>(pending_calls, sender);

--- a/src/anbox/rpc/connection_creator.cpp
+++ b/src/anbox/rpc/connection_creator.cpp
@@ -25,10 +25,8 @@
 namespace ba = boost::asio;
 
 namespace anbox::rpc {
-ConnectionCreator::ConnectionCreator(const std::shared_ptr<Runtime>& rt,
-                                     const MessageProcessorFactory& factory)
-    : runtime_(rt),
-      next_connection_id_(0),
+ConnectionCreator::ConnectionCreator(const MessageProcessorFactory& factory)
+    : next_connection_id_(0),
       connections_(
           std::make_shared<network::Connections<network::SocketConnection>>()),
       message_processor_factory_(factory) {}

--- a/src/anbox/rpc/connection_creator.h
+++ b/src/anbox/rpc/connection_creator.h
@@ -37,8 +37,7 @@ class ConnectionCreator
       const std::shared_ptr<network::MessageSender> &)>
       MessageProcessorFactory;
 
-  ConnectionCreator(const std::shared_ptr<Runtime> &rt,
-                    const MessageProcessorFactory &factory);
+  ConnectionCreator(const MessageProcessorFactory &factory);
   ~ConnectionCreator() noexcept;
 
   void create_connection_for(
@@ -48,7 +47,6 @@ class ConnectionCreator
  private:
   int next_id();
 
-  std::shared_ptr<Runtime> runtime_;
   std::atomic<int> next_connection_id_;
   std::shared_ptr<network::Connections<network::SocketConnection>> const
       connections_;


### PR DESCRIPTION
`rpc::ConnectionCreator` has unused reference to `Runtime` as parameter

* remove parameter