### PR TITLE
Use Docker BuildKit

### DIFF
--- a/scripts/build-with-docker.sh
+++ b/scripts/build-with-docker.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-docker build -t anbox/anbox-builder .
+
+
+# DOCKER_BUILDKIT: alternative docker backend for slight performance improvement
+DOCKER_BUILDKIT=1 docker build -t anbox/anbox-builder .
 docker run --rm --user=$(id -u):$(id -g) --volume=$PWD:/anbox anbox/anbox-builder /anbox/scripts/build.sh $@


### PR DESCRIPTION
Docker v18.09+ includes a newer back-end for Linux containers called *BuildKit*. It can be enabled via a simple environment variable.

The simple change comes in with an improvement of 2.6 seconds (3%) for the image build time:

|   job    |   time  | command line |
| -------- | ------- | ------------ |
| master   |  79.95s | `docker build --no-cache --tag=anbox/anbox-build .` | 
| buildkit |  77.35s | `DOCKER_BUILDKIT=1 docker build --no-cache --tag=anbox/anbox-build .` |

Collection of build-perfomance experiments: [anbox-build-perf](https://github.com/jnnksdev/anbox-build-perf)