### PR TITLE
Optionally use installed sdbus-cpp library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,22 @@ set(ANBOX_STATEDIR_FULL "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/anbox")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/anbox/build/config.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/src/anbox/build/config.h)
 
+
+# sdbus-cpp
+#   find includes and code-generator
+find_package(sdbus-c++ QUIET)
+find_program(XML2CPP "sdbus-c++-xml2cpp")
+
+# sdbus-c++-xml2cpp should be in PATH when building with docker container
+if(${sdbus-c++_FOUND} AND (NOT XML2CPP STREQUAL "XML2CPP-NOTFOUND"))
+  message(STATUS "sdbus-cpp: use installed library")
+  set(COMPILE_SDBUS_CPP FALSE)
+else()
+  message(STATUS "sdbus-cpp: compile from source")
+  set(COMPILE_SDBUS_CPP TRUE)
+endif()
+
+
 add_subdirectory(external)
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,7 @@ FROM base as anbox
 
 # hadolint ignore=DL3008
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --yes \
-  # build-essential \ in base
   ca-certificates \
-  # cmake \ in base
   cmake-data \
   cmake-extras \
   debhelper \
@@ -61,7 +59,6 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --y
   libsdl2-image-dev \
   libsystemd-dev \
   lxc-dev \
-  # pkg-config \ needed for sdbus-cpp
   python3 \
   protobuf-compiler && \
   apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,39 @@
-FROM ubuntu:20.04
+# ---- BASE IMAGE
+FROM ubuntu:20.04 as base
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --yes \
+    build-essential \
+    cmake
+
+
+# ---- COMPILE SDBUS-C++
+FROM base as sdbus-cpp
+
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --yes \
+  build-essential \
+  libsystemd-dev \
+  pkg-config \
+  libexpat1-dev
+
+# copy and build library sdbus-cpp
+RUN mkdir -p /tmp/
+COPY external/sdbus-cpp /tmp/sdbus-cpp
+RUN   cmake -S/tmp/sdbus-cpp -B/tmp/sdbus-cpp/build \
+        -DBUILD_CODE_GEN=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+    && make --directory=/tmp/sdbus-cpp/build --jobs=8
+    
+
+
+# ---- COMPILE ANBOX
+FROM base as anbox
 
 # hadolint ignore=DL3008
-RUN apt-get update && \
-  DEBIAN_FRONTEND="noninteractive" apt-get install -qq -y --no-install-recommends \
-  build-essential \
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --yes \
+  # build-essential \ in base
   ca-certificates \
-  cmake \
+  # cmake \ in base
   cmake-data \
   cmake-extras \
   debhelper \
@@ -33,10 +61,14 @@ RUN apt-get update && \
   libsdl2-image-dev \
   libsystemd-dev \
   lxc-dev \
-  pkg-config \
+  # pkg-config \ needed for sdbus-cpp
   python3 \
   protobuf-compiler && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+COPY --from=sdbus-cpp /tmp/sdbus-cpp /tmp/sdbus-cpp
+RUN make --directory=/tmp/sdbus-cpp/build install
+RUN ls -l /usr/local/bin/sdbus-c++-xml2cpp
 
 WORKDIR /anbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,9 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --y
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# install sdbus-cpp and add to path
 COPY --from=sdbus-cpp /tmp/sdbus-cpp /tmp/sdbus-cpp
 RUN make --directory=/tmp/sdbus-cpp/build install
-RUN ls -l /usr/local/bin/sdbus-c++-xml2cpp
+ENV PATH="/usr/local/bin/sdbus-c++-xml2cpp:${PATH}"
 
 WORKDIR /anbox

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -6,12 +6,12 @@ add_subdirectory(backward-cpp)
 set(BUILD_TESTING OFF)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 add_subdirectory(cpu_features)
-include(ExternalProject)
-ExternalProject_Add(sdbus-cpp
-  PREFIX sdbus-cpp
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sdbus-cpp"
-  INSTALL_COMMAND ""
-  CMAKE_CACHE_ARGS
-        -DBUILD_CODE_GEN:BOOL=ON
-        -DBUILD_SHARED_LIBS:BOOL=OFF
-)
+#include(ExternalProject)
+#ExternalProject_Add(sdbus-cpp
+#  PREFIX sdbus-cpp
+#  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sdbus-cpp"
+#  INSTALL_COMMAND ""
+#  CMAKE_CACHE_ARGS
+#        -DBUILD_CODE_GEN:BOOL=ON
+#        -DBUILD_SHARED_LIBS:BOOL=OFF
+#)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -6,12 +6,16 @@ add_subdirectory(backward-cpp)
 set(BUILD_TESTING OFF)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 add_subdirectory(cpu_features)
-#include(ExternalProject)
-#ExternalProject_Add(sdbus-cpp
-#  PREFIX sdbus-cpp
-#  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sdbus-cpp"
-#  INSTALL_COMMAND ""
-#  CMAKE_CACHE_ARGS
-#        -DBUILD_CODE_GEN:BOOL=ON
-#        -DBUILD_SHARED_LIBS:BOOL=OFF
-#)
+
+if(COMPILE_SDBUS_CPP)
+    include(ExternalProject)
+    ExternalProject_Add(sdbus-cpp
+        PREFIX sdbus-cpp
+        SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sdbus-cpp"
+        INSTALL_COMMAND ""
+        CMAKE_CACHE_ARGS
+                -DBUILD_CODE_GEN:BOOL=ON
+                -DBUILD_SHARED_LIBS:BOOL=OFF
+    )
+endif()
+

--- a/scripts/build-with-docker.sh
+++ b/scripts/build-with-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-docker build -t anbox/anbox-builder .
+DOCKER_BUILDKIT=1 docker build -t anbox/anbox-builder .
 docker run --rm --user=$(id -u):$(id -g) --volume=$PWD:/anbox anbox/anbox-builder /anbox/scripts/build.sh $@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,8 @@ add_library(anbox-protobuf
 target_link_libraries(anbox-protobuf
     ${PROTOBUF_LITE_LIBRARIES})
 
-set(XML2CPP ${CMAKE_BINARY_DIR}/external/sdbus-cpp/src/sdbus-cpp-build/tools/sdbus-c++-xml2cpp)
+# use precompiled binary
+set(XML2CPP /usr/local/bin/sdbus-c++-xml2cpp)
 
 macro(DBusServer BaseName)
     add_custom_command(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,6 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/external/android-emugl/host/libs/renderControl_dec
   ${CMAKE_BINARY_DIR}/external/android-emugl/host/libs/renderControl_dec
   ${CMAKE_SOURCE_DIR}/external/cpu_features/include
-  ${CMAKE_SOURCE_DIR}/external/sdbus-cpp/include
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBINDERFS_PATH=\"\\\"${BINDERFS_PATH}\\\"\"")
@@ -59,8 +58,22 @@ add_library(anbox-protobuf
 target_link_libraries(anbox-protobuf
     ${PROTOBUF_LITE_LIBRARIES})
 
-# use precompiled binary
-set(XML2CPP /usr/local/bin/sdbus-c++-xml2cpp)
+    
+# sdbus-cpp
+#   set includes and code-generator
+if(COMPILE_SDBUS_CPP)
+    # in-tree binary and includes
+    set(XML2CPP ${CMAKE_BINARY_DIR}/external/sdbus-cpp/src/sdbus-cpp-build/tools/sdbus-c++-xml2cpp)
+    include_directories(
+        ${CMAKE_SOURCE_DIR}/external/sdbus-cpp/include
+    )
+else()
+    # installed binary (must be in PATH) and includes
+    set(XML2CPP sdbus-c++-xml2cpp)
+    include_directories(
+        /usr/local/include/sdbus-c++
+    )
+endif()
 
 macro(DBusServer BaseName)
     add_custom_command(


### PR DESCRIPTION

This PR implements a compile-once solution for the external project `sdbus-cpp` used for the docker container build toolchain.
The installed library is used instead of building the in-tree module when it can be found with cmake `find_package`.
A fallback was implemented to avoid build errors in case the library is not installed on the host.

This is a small study to reduce build times by providing precompiled resources before Anbox is built.
The performance improvement is for niche use cases where the entire project is fully rebuild multiple times.

By introducing other concepts, the overall build time is reduced anyways. For example docker *BuildKit*, which reduces the buld time for the `anbox-build` image.

|job|master (s)|this PR (s)|diff (master - PR in s)|
|---|---|---|---|
|scripts/build.sh|60.41|59.51|0.9|
|scripts/build-with-docker.sh|61.28|60.15|1.13|
|scripts/build-with-docker.sh (docker --no-cache)|163.44|156.99|6.45|

When accepted this will be a reference implementation with the other external modules following in the same style.

@morphis In  `src/CMakeLists.txt` the include path for `sdbus-cpp` is hardcoded. I would like to use something like `sdbus-c++_INLCUDE_DIRS`, but the variable was empty. Do you know a work-around?