### PR TITLE
use #pragma once instead of old-school include header

### DIFF
--- a/src/anbox/android/intent.h
+++ b/src/anbox/android/intent.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_ANDROID_INTENT_H_
-#define ANBOX_ANDROID_INTENT_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -36,4 +35,3 @@ struct Intent {
 
 std::ostream &operator<<(std::ostream &out, const Intent &intent);
 }
-#endif

--- a/src/anbox/android/ip_config_builder.h
+++ b/src/anbox/android/ip_config_builder.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_ANDROID_IPCONFIGBUILDER_H_
-#define ANBOX_ANDROID_IPCONFIGBUILDER_H_
+#pragma once
 
 #include "anbox/common/binary_writer.h"
 
@@ -60,4 +59,4 @@ class IpConfigBuilder {
   std::uint32_t id_;
 };
 }
-#endif
+

--- a/src/anbox/application/database.h
+++ b/src/anbox/application/database.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_APPLICATION_DATABASE_H_
-#define ANBOX_APPLICATION_DATABASE_H_
+#pragma once
 
 #include "anbox/android/intent.h"
 
@@ -53,4 +52,3 @@ class Database {
   bool done_reset = false;
 };
 }
-#endif

--- a/src/anbox/application/gps_info_broker.h
+++ b/src/anbox/application/gps_info_broker.h
@@ -1,5 +1,4 @@
-#ifndef ANBOX_APPLICATION_GPS_INFO_BROKER_H_
-#define ANBOX_APPLICATION_GPS_INFO_BROKER_H_
+#pragma once
 
 #include <boost/signals2.hpp>
 #include <string>
@@ -11,4 +10,3 @@ struct GpsInfoBroker : public DoNotCopyOrMove {
   boost::signals2::signal<void(const std::string&)> newNmeaSentence;
 };
 }
-#endif

--- a/src/anbox/application/launcher_storage.h
+++ b/src/anbox/application/launcher_storage.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_APPLICATION_LAUNCHER_STORAGE_H_
-#define ANBOX_APPLICATION_LAUNCHER_STORAGE_H_
+#pragma once
 
 #include "anbox/application/database.h"
 #include "anbox/android/intent.h"
@@ -45,4 +44,3 @@ class LauncherStorage {
   boost::filesystem::path path_;
 };
 }
-#endif

--- a/src/anbox/application/manager.h
+++ b/src/anbox/application/manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_APPLICATION_MANAGER_H_
-#define ANBOX_APPLICATION_MANAGER_H_
+#pragma once
 
 #include "anbox/android/intent.h"
 #include "anbox/do_not_copy_or_move.h"
@@ -65,4 +64,3 @@ class RestrictedManager : public Manager {
   wm::Stack::Id launch_stack_;
 };
 }
-#endif

--- a/src/anbox/application/sensor_type.h
+++ b/src/anbox/application/sensor_type.h
@@ -1,5 +1,4 @@
-#ifndef ANBOX_APPLICATION_SENSOR_TYPE_H_
-#define ANBOX_APPLICATION_SENSOR_TYPE_H_
+#pragma once
 
 #include <string>
 
@@ -20,4 +19,3 @@ class SensorTypeHelper {
   static SensorType FromString(const std::string& str);
 };
 }
-#endif

--- a/src/anbox/application/sensors_state.h
+++ b/src/anbox/application/sensors_state.h
@@ -1,5 +1,4 @@
-#ifndef ANBOX_APPLICATION_SENSORS_STATE_H_
-#define ANBOX_APPLICATION_SENSORS_STATE_H_
+#pragma once
 
 #include <cstdint>
 #include <tuple>
@@ -31,4 +30,3 @@ struct SensorsState : public DoNotCopyOrMove {
   double humidity;
 };
 }
-#endif

--- a/src/anbox/audio/client_info.h
+++ b/src/anbox/audio/client_info.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_AUDIO_CLIENT_INFO_H_
-#define ANBOX_AUDIO_CLIENT_INFO_H_
+#pragma once
 
 #include <cstdint>
 
@@ -30,4 +29,3 @@ struct ClientInfo {
   Type type;
 };
 }
-#endif

--- a/src/anbox/audio/server.h
+++ b/src/anbox/audio/server.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_AUDIO_SERVER_H_
-#define ANBOX_AUDIO_SERVER_H_
+#pragma once
 
 #include "anbox/runtime.h"
 #include "anbox/audio/client_info.h"
@@ -51,4 +50,3 @@ class Server {
   std::atomic<int> next_id_;
 };
 }
-#endif

--- a/src/anbox/audio/sink.h
+++ b/src/anbox/audio/sink.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_AUDIO_SINK_H_
-#define ANBOX_AUDIO_SINK_H_
+#pragma once
 
 #include <cstdint>
 
@@ -29,4 +28,3 @@ class Sink {
   virtual void write_data(const std::vector<std::uint8_t> &data) = 0;
 };
 }
-#endif

--- a/src/anbox/audio/source.h
+++ b/src/anbox/audio/source.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_AUDIO_SOURCE_H_
-#define ANBOX_AUDIO_SOURCE_H_
+#pragma once
 
 #include <cstdint>
 
@@ -30,4 +29,3 @@ class Source {
   virtual void read_data(std::vector<std::uint8_t> &data) = 0;
 };
 }
-#endif

--- a/src/anbox/bridge/android_api_stub.h
+++ b/src/anbox/bridge/android_api_stub.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_BRIDGE_ANDROID_API_STUB_H_
-#define ANBOX_BRIDGE_ANDROID_API_STUB_H_
+#pragma once
 
 #include "anbox/application/manager.h"
 #include "anbox/common/wait_handle.h"
@@ -78,4 +77,3 @@ class AndroidApiStub : public anbox::application::Manager {
   core::Property<bool> ready_;
 };
 }
-#endif

--- a/src/anbox/bridge/platform_api_skeleton.h
+++ b/src/anbox/bridge/platform_api_skeleton.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_BRIDGE_PLATFORM_SERVER_H_
-#define ANBOX_BRIDGE_PLATFORM_SERVER_H_
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -84,5 +83,3 @@ class PlatformApiSkeleton {
 };
 }
 
-
-#endif

--- a/src/anbox/bridge/platform_message_processor.h
+++ b/src/anbox/bridge/platform_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_BRIDGE_PLATFORM_MESSAGE_PROCESSOR_H_
-#define ANBOX_BRIDGE_PLATFORM_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/rpc/message_processor.h"
 
@@ -38,4 +37,3 @@ class PlatformMessageProcessor : public rpc::MessageProcessor {
 };
 }
 
-#endif

--- a/src/anbox/build/config.h.in
+++ b/src/anbox/build/config.h.in
@@ -17,8 +17,7 @@
  *
  */
 
-#ifndef ANBOX_CONFIG_H_
-#define ANBOX_CONFIG_H_
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -31,5 +30,3 @@ static constexpr const char *version{"@ANBOX_VERSION@"};
 static constexpr const char *default_resource_path{"@ANBOX_RESOURCE_DIR_FULL@"};
 static constexpr const char *default_data_path{"@ANBOX_STATEDIR_FULL@"};
 }
-
-#endif  // ANBOX_CONFIG_H_

--- a/src/anbox/cli.h
+++ b/src/anbox/cli.h
@@ -16,8 +16,7 @@
  * Authored by: Thomas Voß <thomas.voss@canonical.com>
  *
  */
-#ifndef BIOMETRY_UTIL_CLI_H_
-#define BIOMETRY_UTIL_CLI_H_
+#pragma once
 
 #include <iomanip>
 #include <iostream>
@@ -383,4 +382,3 @@ inline BoolSwitchFlag::Ptr make_flag(const Name& name,
 }  // namespace cli
 }  // namespace anbox
 
-#endif

--- a/src/anbox/cmds/check_features.h
+++ b/src/anbox/cmds/check_features.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_CHECK_FEATURES_H_
-#define ANBOX_CMDS_CHECK_FEATURES_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -33,4 +32,3 @@ class CheckFeatures : public cli::CommandWithFlagsAndAction {
   bool sanity_check_for_features();
 };
 }
-#endif

--- a/src/anbox/cmds/container_manager.h
+++ b/src/anbox/cmds/container_manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_CONTAINER_MANAGER_H_
-#define ANBOX_CMDS_CONTAINER_MANAGER_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -50,4 +49,3 @@ class ContainerManager : public cli::CommandWithFlagsAndAction {
   std::string container_network_dns_servers_;
 };
 }
-#endif

--- a/src/anbox/cmds/install.h
+++ b/src/anbox/cmds/install.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_INSTALL_H_
-#define ANBOX_CMDS_INSTALL_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -33,4 +32,3 @@ class Install : public cli::CommandWithFlagsAndAction {
   std::string apk_;
 };
 }
-#endif

--- a/src/anbox/cmds/launch.h
+++ b/src/anbox/cmds/launch.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_LAUNCH_H_
-#define ANBOX_CMDS_LAUNCH_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -39,4 +38,3 @@ class Launch : public cli::CommandWithFlagsAndAction {
   bool use_system_dbus_ = false;
 };
 }
-#endif

--- a/src/anbox/cmds/session_manager.h
+++ b/src/anbox/cmds/session_manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_RUN_H_
-#define ANBOX_CMDS_RUN_H_
+#pragma once
 
 #include "anbox/cli.h"
 
@@ -56,4 +55,3 @@ class SessionManager : public cli::CommandWithFlagsAndAction {
   bool server_side_decoration_ = false;
 };
 }
-#endif

--- a/src/anbox/cmds/system_info.h
+++ b/src/anbox/cmds/system_info.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_SYSTEM_INFO_H_
-#define ANBOX_CMDS_SYSTEM_INFO_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -30,4 +29,3 @@ class SystemInfo : public cli::CommandWithFlagsAndAction {
   SystemInfo();
 };
 }
-#endif

--- a/src/anbox/cmds/version.h
+++ b/src/anbox/cmds/version.h
@@ -17,8 +17,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_VERSION_H_
-#define ANBOX_CMDS_VERSION_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -32,4 +31,3 @@ class Version : public cli::CommandWithFlagsAndAction {
   Version();
 };
 }
-#endif

--- a/src/anbox/cmds/wait_ready.h
+++ b/src/anbox/cmds/wait_ready.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CMDS_WAIT_READY_H_
-#define ANBOX_CMDS_WAIT_READY_H_
+#pragma once
 
 #include <functional>
 #include <iostream>
@@ -33,4 +32,3 @@ class WaitReady : public cli::CommandWithFlagsAndAction {
   bool use_system_dbus_ = false;
 };
 }
-#endif

--- a/src/anbox/common/binary_writer.h
+++ b/src/anbox/common/binary_writer.h
@@ -16,8 +16,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_BINARY_WRITER_H_
-#define ANBOX_COMMON_BINARY_WRITER_H_
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -51,4 +50,3 @@ class BinaryWriter {
   Order byte_order_;
 };
 }
-#endif

--- a/src/anbox/common/binder_device.h
+++ b/src/anbox/common/binder_device.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_BINDER_DEVICE_H_
-#define ANBOX_COMMON_BINDER_DEVICE_H_
+#pragma once
 
 #include "anbox/common/fd.h"
 
@@ -37,4 +36,3 @@ class BinderDevice {
   const std::string path_;
 };
 }
-#endif

--- a/src/anbox/common/binder_device_allocator.h
+++ b/src/anbox/common/binder_device_allocator.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_BINDER_DEVICE_ALLOCATOR_H_
-#define ANBOX_COMMON_BINDER_DEVICE_ALLOCATOR_H_
+#pragma once
 
 #include <memory>
 
@@ -28,4 +27,3 @@ class BinderDeviceAllocator {
   static std::unique_ptr<BinderDevice> new_device();
 };
 }
-#endif

--- a/src/anbox/common/binderfs.h
+++ b/src/anbox/common/binderfs.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_BINDERFS_H_
-#define ANBOX_COMMON_BINDERFS_H_
+#pragma once
 
 #include <linux/types.h>
 #include <linux/ioctl.h>
@@ -41,4 +40,3 @@ struct binderfs_device {
  */
 #define BINDER_CTL_ADD _IOWR('b', 1, struct binderfs_device)
 
-#endif

--- a/src/anbox/common/dispatcher.h
+++ b/src/anbox/common/dispatcher.h
@@ -17,8 +17,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_DISPATCHER_H_
-#define ANBOX_COMMON_DISPATCHER_H_
+#pragma once
 
 #include "anbox/do_not_copy_or_move.h"
 #include "anbox/runtime.h"
@@ -38,4 +37,3 @@ class Dispatcher : public DoNotCopyOrMove {
 std::shared_ptr<Dispatcher> create_dispatcher_for_runtime(
     const std::shared_ptr<Runtime>&);
 }
-#endif

--- a/src/anbox/common/fd.h
+++ b/src/anbox/common/fd.h
@@ -16,8 +16,7 @@
  * Authored by: Kevin DuBois <kevin.dubois@canonical.com>
  */
 
-#ifndef ANBOX_COMMON_FD_H_
-#define ANBOX_COMMON_FD_H_
+#pragma once
 
 #include <memory>
 
@@ -47,4 +46,3 @@ class Fd {
 };
 }  // namespace anbox
 
-#endif

--- a/src/anbox/common/fd_sets.h
+++ b/src/anbox/common/fd_sets.h
@@ -16,8 +16,7 @@
  * Authored by: Robert Carr <robert.carr@canonical.com>
  */
 
-#ifndef ANBOX_COMMON_FD_SETS_H_
-#define ANBOX_COMMON_FD_SETS_H_
+#pragma once
 
 #include <initializer_list>
 #include <vector>
@@ -28,4 +27,3 @@ namespace anbox {
 typedef std::vector<std::vector<Fd>> FdSets;
 }  // namespace anbox
 
-#endif

--- a/src/anbox/common/loop_device.h
+++ b/src/anbox/common/loop_device.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_LOOP_DEVICE_H_
-#define ANBOX_COMMON_LOOP_DEVICE_H_
+#pragma once
 
 #include "anbox/common/fd.h"
 
@@ -40,4 +39,3 @@ class LoopDevice {
   boost::filesystem::path path_;
 };
 }
-#endif

--- a/src/anbox/common/loop_device_allocator.h
+++ b/src/anbox/common/loop_device_allocator.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_LOOP_DEVICE_ALLOCATOR_H_
-#define ANBOX_COMMON_LOOP_DEVICE_ALLOCATOR_H_
+#pragma once
 
 #include <memory>
 
@@ -27,4 +26,3 @@ class LoopDeviceAllocator {
   static std::shared_ptr<LoopDevice> new_device();
 };
 }
-#endif

--- a/src/anbox/common/message_channel.h
+++ b/src/anbox/common/message_channel.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ANBOX_COMMON_MESSAGE_CHANNEL_H
-#define ANBOX_COMMON_MESSAGE_CHANNEL_H
+#pragma once
 
 #include <stddef.h>
 
@@ -93,4 +92,3 @@ class MessageChannel : public MessageChannelBase {
   T mItems[CAPACITY];
 };
 }
-#endif

--- a/src/anbox/common/mount_entry.h
+++ b/src/anbox/common/mount_entry.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_COMMON_MOUNT_ENTRY_H_
-#define ANBOX_COMMON_MOUNT_ENTRY_H_
+#pragma once
 
 #include <boost/filesystem/path.hpp>
 
@@ -42,4 +41,3 @@ class MountEntry {
   boost::filesystem::path target_;
 };
 }
-#endif

--- a/src/anbox/common/variable_length_array.h
+++ b/src/anbox/common/variable_length_array.h
@@ -16,8 +16,7 @@
  * Authored by: Alexandros Frantzis <alexandros.frantzis@canonical.com>
  */
 
-#ifndef ANBOX_COMMON_VARIABLE_LENGTH_ARRAY_H_
-#define ANBOX_COMMON_VARIABLE_LENGTH_ARRAY_H_
+#pragma once
 
 #include <sys/types.h>
 #include <memory>
@@ -55,4 +54,3 @@ class VariableLengthArray {
 };
 }  // namespace anbox
 
-#endif

--- a/src/anbox/common/wait_handle.h
+++ b/src/anbox/common/wait_handle.h
@@ -17,8 +17,7 @@
  *              Daniel van Vugt <daniel.van.vugt@canonical.com>
  */
 
-#ifndef ANBOX_COMMON_WAIT_HANDLE_H_
-#define ANBOX_COMMON_WAIT_HANDLE_H_
+#pragma once
 
 #include <chrono>
 #include <condition_variable>
@@ -47,4 +46,3 @@ struct WaitHandle {
   int received;
 };
 }
-#endif

--- a/src/anbox/container/client.h
+++ b/src/anbox/container/client.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_CLIENT_H_
-#define ANBOX_CONTAINER_CLIENT_H_
+#pragma once
 
 #include "anbox/container/configuration.h"
 #include "anbox/runtime.h"
@@ -59,4 +58,3 @@ class Client {
   TerminateCallback terminate_callback_;
 };
 }
-#endif

--- a/src/anbox/container/configuration.h
+++ b/src/anbox/container/configuration.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_CONFIGURATION_H_
-#define ANBOX_CONTAINER_CONFIGURATION_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -34,4 +33,3 @@ struct Configuration {
   std::vector<std::string> extra_properties;
 };
 }
-#endif

--- a/src/anbox/container/container.h
+++ b/src/anbox/container/container.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_CONTAINER_H_
-#define ANBOX_CONTAINER_CONTAINER_H_
+#pragma once
 
 #include "anbox/container/configuration.h"
 
@@ -43,4 +42,3 @@ class Container {
   virtual State state() = 0;
 };
 }
-#endif

--- a/src/anbox/container/lxc_container.h
+++ b/src/anbox/container/lxc_container.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_LXC_CONTAINER_H_
-#define ANBOX_CONTAINER_LXC_CONTAINER_H_
+#pragma once
 
 #include "anbox/container/container.h"
 #include "anbox/network/credentials.h"
@@ -66,4 +65,3 @@ class LxcContainer : public Container {
 // get_id_map() is published for unit testing
 std::vector<std::string> get_id_map(uid_t uid, gid_t gid);
 }
-#endif

--- a/src/anbox/container/management_api_message_processor.h
+++ b/src/anbox/container/management_api_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_MANAGEMENT_API_MESSAGE_PROCESSOR_H_
-#define ANBOX_CONTAINER_MANAGEMENT_API_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/rpc/message_processor.h"
 
@@ -40,4 +39,3 @@ class ManagementApiMessageProcessor : public rpc::MessageProcessor {
 }  // namespace anbox
 }  // namespace network
 
-#endif

--- a/src/anbox/container/management_api_skeleton.h
+++ b/src/anbox/container/management_api_skeleton.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_MANAGEMENT_API_SKELETON_H_
-#define ANBOX_CONTAINER_MANAGEMENT_API_SKELETON_H_
+#pragma once
 
 #include <memory>
 
@@ -58,4 +57,3 @@ class ManagementApiSkeleton {
 };
 }
 
-#endif

--- a/src/anbox/container/management_api_stub.h
+++ b/src/anbox/container/management_api_stub.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_MANAGEMENT_API_STUB_H_
-#define ANBOX_CONTAINER_MANAGEMENT_API_STUB_H_
+#pragma once
 
 #include "anbox/common/wait_handle.h"
 #include "anbox/container/configuration.h"
@@ -58,4 +57,3 @@ class ManagementApiStub : public DoNotCopyOrMove {
   static const std::chrono::milliseconds stop_waiting_timeout;
 };
 }
-#endif

--- a/src/anbox/container/service.h
+++ b/src/anbox/container/service.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_CONTAINER_SERVICE_H_
-#define ANBOX_CONTAINER_SERVICE_H_
+#pragma once
 
 #include "anbox/common/dispatcher.h"
 #include "anbox/container/container.h"
@@ -57,4 +56,3 @@ class Service : public std::enable_shared_from_this<Service> {
   Configuration config_;
 };
 }
-#endif

--- a/src/anbox/daemon.h
+++ b/src/anbox/daemon.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DAEMON_H_
-#define ANBOX_DAEMON_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -36,4 +35,3 @@ class Daemon : public DoNotCopyOrMove {
 };
 }  // namespace anbox
 
-#endif

--- a/src/anbox/dbus/bus.h
+++ b/src/anbox/dbus/bus.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DBUS_BUS_H_
-#define ANBOX_DBUS_BUS_H_
+#pragma once
 
 #include "anbox/do_not_copy_or_move.h"
 
@@ -53,4 +52,3 @@ class Bus : public DoNotCopyOrMove {
 };
 using BusPtr = std::shared_ptr<Bus>;
 }
-#endif

--- a/src/anbox/dbus/gps_server.h
+++ b/src/anbox/dbus/gps_server.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DBUS_GPS_SERVER_H_
-#define ANBOX_DBUS_GPS_SERVER_H_
+#pragma once
 
 #include <sdbus-c++/sdbus-c++.h>
 
@@ -40,4 +39,3 @@ class GpsServer : public sdbus::AdaptorInterfaces<org::anbox::Gps_adaptor> {
   const std::shared_ptr<anbox::application::GpsInfoBroker> gps_info_broker_;
 };
 
-#endif

--- a/src/anbox/dbus/interface.h
+++ b/src/anbox/dbus/interface.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DBUS_INTERFACE_H_
-#define ANBOX_DBUS_INTERFACE_H_
+#pragma once
 
 namespace anbox::dbus::interface {
 struct Service {
@@ -24,4 +23,3 @@ struct Service {
   static inline const char* path() { return "/org/anbox"; }
 };
 }
-#endif

--- a/src/anbox/dbus/sensors_server.h
+++ b/src/anbox/dbus/sensors_server.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DBUS_SENSORS_SERVER_H_
-#define ANBOX_DBUS_SENSORS_SERVER_H_
+#pragma once
 
 #include <sdbus-c++/sdbus-c++.h>
 
@@ -55,4 +54,3 @@ class SensorsServer : public sdbus::AdaptorInterfaces<org::anbox::Sensors_adapto
   const std::shared_ptr<anbox::application::SensorsState> impl_;
 };
 
-#endif

--- a/src/anbox/defer_action.h
+++ b/src/anbox/defer_action.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DEFER_ACTION_H_
-#define ANBOX_DEFER_ACTION_H_
+#pragma once
 
 #include <functional>
 
@@ -38,4 +37,3 @@ class DeferAction : public DoNotCopyOrMove {
 
 }  // namespace anbox
 
-#endif

--- a/src/anbox/do_not_copy_or_move.h
+++ b/src/anbox/do_not_copy_or_move.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_DO_NOT_COPY_OR_MOVE_H_
-#define ANBOX_DO_NOT_COPY_OR_MOVE_H_
+#pragma once
 
 namespace anbox {
 
@@ -33,4 +32,3 @@ class DoNotCopyOrMove {
 };
 }
 
-#endif

--- a/src/anbox/graphics/buffer_queue.h
+++ b/src/anbox/graphics/buffer_queue.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ANBOX_GRAPHICS_BUFFER_QUEUE_H_
-#define ANBOX_GRAPHICS_BUFFER_QUEUE_H_
+#pragma once
 
 #include "anbox/common/small_vector.h"
 
@@ -50,4 +49,3 @@ class BufferQueue {
 };
 
 }
-#endif

--- a/src/anbox/graphics/buffered_io_stream.h
+++ b/src/anbox/graphics/buffered_io_stream.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_BUFFERED_IO_STREAM_H_
-#define ANBOX_GRAPHICS_BUFFERED_IO_STREAM_H_
+#pragma once
 
 #include "external/android-emugl/host/include/libOpenglRender/IOStream.h"
 
@@ -59,4 +58,3 @@ class BufferedIOStream : public IOStream {
   std::thread worker_thread_;
 };
 }
-#endif

--- a/src/anbox/graphics/density.h
+++ b/src/anbox/graphics/density.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_DENSITY_H_
-#define ANBOX_GRAPHICS_DENSITY_H_
+#pragma once
 
 namespace anbox::graphics {
 /**
@@ -38,4 +37,3 @@ enum class DensityType {
 DensityType current_density();
 int dp_to_pixel(unsigned int dp);
 }
-#endif

--- a/src/anbox/graphics/emugl/Renderable.h
+++ b/src/anbox/graphics/emugl/Renderable.h
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 
-#ifndef ANBOX_GRAPHICS_EMUGL_RENDERABLE_H_
-#define ANBOX_GRAPHICS_EMUGL_RENDERABLE_H_
+#pragma once
 
 #include "anbox/graphics/rect.h"
 
@@ -66,4 +65,3 @@ std::ostream &operator<<(std::ostream &out, const Renderable &r);
 
 typedef std::vector<Renderable> RenderableList;
 
-#endif

--- a/src/anbox/graphics/gl_extensions.h
+++ b/src/anbox/graphics/gl_extensions.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_GL_EXTENSIONS_H_
-#define ANBOX_GRAPHICS_GL_EXTENSIONS_H_
+#pragma once
 
 #include <stdexcept>
 #include <string.h>
@@ -50,4 +49,3 @@ class GLExtensions {
   char const* extensions;
 };
 }
-#endif

--- a/src/anbox/graphics/gl_renderer_server.h
+++ b/src/anbox/graphics/gl_renderer_server.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_GL_RENDERER_SERVER_H_
-#define ANBOX_GRAPHICS_GL_RENDERER_SERVER_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -60,4 +59,3 @@ class GLRendererServer {
 };
 
 }
-#endif

--- a/src/anbox/graphics/layer_composer.h
+++ b/src/anbox/graphics/layer_composer.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_LAYER_COMPOSER_H_
-#define ANBOX_GRAPHICS_LAYER_COMPOSER_H_
+#pragma once
 
 #include "anbox/graphics/renderer.h"
 
@@ -50,4 +49,3 @@ class LayerComposer {
   std::shared_ptr<Strategy> strategy_;
 };
 }
-#endif

--- a/src/anbox/graphics/multi_window_composer_strategy.h
+++ b/src/anbox/graphics/multi_window_composer_strategy.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_MULTI_WINDOW_COMPOSER_STRATEGY_H_
-#define ANBOX_GRAPHICS_MULTI_WINDOW_COMPOSER_STRATEGY_H_
+#pragma once
 
 #include "anbox/graphics/layer_composer.h"
 
@@ -34,4 +33,3 @@ private:
   std::shared_ptr<wm::Manager> wm_;
 };
 }
-#endif

--- a/src/anbox/graphics/opengles_message_processor.h
+++ b/src/anbox/graphics/opengles_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_OPENGLES_MESSAGE_PROCESSOR_H_
-#define ANBOX_GRAPHICS_OPENGLES_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 #include "anbox/network/socket_connection.h"
@@ -50,4 +49,3 @@ class OpenGlesMessageProcessor : public network::MessageProcessor {
   std::shared_ptr<RenderThread> render_thread_;
 };
 }
-#endif

--- a/src/anbox/graphics/primitives.h
+++ b/src/anbox/graphics/primitives.h
@@ -17,8 +17,7 @@
  *              Kevin DuBois <kevin.dubois@canonical.com>
  */
 
-#ifndef ANBOX_GRAPHICS_PRIMITIVES_H_
-#define ANBOX_GRAPHICS_PRIMITIVES_H_
+#pragma once
 
 #include <GLES2/gl2.h>
 
@@ -41,4 +40,3 @@ struct Primitive {
   Vertex vertices[max_vertices];
 };
 }
-#endif

--- a/src/anbox/graphics/program_family.h
+++ b/src/anbox/graphics/program_family.h
@@ -16,8 +16,7 @@
  * Authored by: Daniel van Vugt <daniel.van.vugt@canonical.com>
  */
 
-#ifndef ANBOX_GRAPHICS_PROGRAM_FAMILY_H_
-#define ANBOX_GRAPHICS_PROGRAM_FAMILY_H_
+#pragma once
 
 #include <map>
 #include <unordered_map>
@@ -59,4 +58,3 @@ class ProgramFamily {
   std::map<ShaderPair, Program> program;
 };
 }
-#endif  // MIR_RENDERER_GL_PROGRAM_FAMILY_H_

--- a/src/anbox/graphics/rect.h
+++ b/src/anbox/graphics/rect.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_RECT_H_
-#define ANBOX_GRAPHICS_RECT_H_
+#pragma once
 
 #include <cstdint>
 
@@ -76,4 +75,3 @@ class Rect {
 std::ostream &operator<<(std::ostream &out, const Rect &rect);
 std::istream& operator>>(std::istream& in, anbox::graphics::Rect &rect);
 }
-#endif

--- a/src/anbox/graphics/renderer.h
+++ b/src/anbox/graphics/renderer.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_RENDERER_H_
-#define ANBOX_GRAPHICS_RENDERER_H_
+#pragma once
 
 #include "anbox/graphics/emugl/Renderable.h"
 
@@ -32,4 +31,3 @@ class Renderer {
                     const RenderableList& renderables) = 0;
 };
 }
-#endif

--- a/src/anbox/graphics/single_window_composer_strategy.h
+++ b/src/anbox/graphics/single_window_composer_strategy.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_GRAPHICS_SINGLE_WINDOW_COMPOSER_STRATEGY_H_
-#define ANBOX_GRAPHICS_SINGLE_WINDOW_COMPOSER_STRATEGY_H_
+#pragma once
 
 #include "anbox/graphics/layer_composer.h"
 
@@ -34,4 +33,3 @@ private:
   std::shared_ptr<wm::Manager> wm_;
 };
 }
-#endif

--- a/src/anbox/input/device.h
+++ b/src/anbox/input/device.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_INPUT_DEVICE_H_
-#define ANBOX_INPUT_DEVICE_H_
+#pragma once
 
 #include "anbox/network/connections.h"
 #include "anbox/network/published_socket_connector.h"
@@ -97,4 +96,3 @@ class Device : public std::enable_shared_from_this<Device> {
   Info info_;
 };
 }
-#endif

--- a/src/anbox/input/manager.h
+++ b/src/anbox/input/manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_INPUT_MANAGER_H_
-#define ANBOX_INPUT_MANAGER_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -42,4 +41,3 @@ class Manager {
   std::map<std::uint32_t, std::shared_ptr<Device>> devices_;
 };
 }
-#endif

--- a/src/anbox/logger.h
+++ b/src/anbox/logger.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_LOGGER_H_
-#define ANBOX_LOGGER_H_
+#pragma once
 
 #include <boost/optional.hpp>
 
@@ -147,4 +146,3 @@ void SetLogger(const std::shared_ptr<Logger>& logger);
   anbox::Log().Fatalf( \
       anbox::Logger::Location{__FILE__, __FUNCTION__, __LINE__}, __VA_ARGS__)
 
-#endif

--- a/src/anbox/network/base_socket_messenger.h
+++ b/src/anbox/network/base_socket_messenger.h
@@ -16,8 +16,7 @@
  * Authored by: Kevin DuBois <kevin.dubois@canonical.com>
  */
 
-#ifndef ANBOX_NETWORK_BASE_SOCKET_MESSENGER_H_
-#define ANBOX_NETWORK_BASE_SOCKET_MESSENGER_H_
+#pragma once
 
 #include "anbox/common/fd_sets.h"
 #include "anbox/network/socket_messenger.h"
@@ -59,4 +58,3 @@ class BaseSocketMessenger : public SocketMessenger {
   std::mutex message_lock;
 };
 }
-#endif

--- a/src/anbox/network/connection_context.h
+++ b/src/anbox/network/connection_context.h
@@ -16,8 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef ANBOX_NETWORK_CONNECTION_CONTEXT_H_
-#define ANBOX_NETWORK_CONNECTION_CONTEXT_H_
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -41,4 +40,3 @@ class ConnectionContext {
 };
 }
 
-#endif

--- a/src/anbox/network/connection_creator.h
+++ b/src/anbox/network/connection_creator.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_CONNECTION_CREATOR_H_
-#define ANBOX_NETWORK_CONNECTION_CREATOR_H_
+#pragma once
 
 #include <boost/asio.hpp>
 
@@ -32,4 +31,3 @@ class ConnectionCreator : public DoNotCopyOrMove {
           socket) = 0;
 };
 }
-#endif

--- a/src/anbox/network/connections.h
+++ b/src/anbox/network/connections.h
@@ -16,8 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef ANBOX_NETWORK_CONNECTIONS_H_
-#define ANBOX_NETWORK_CONNECTIONS_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -63,4 +62,3 @@ class Connections {
 };
 }
 
-#endif

--- a/src/anbox/network/connector.h
+++ b/src/anbox/network/connector.h
@@ -15,12 +15,10 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_CONNECTOR_H
-#define ANBOX_NETWORK_CONNECTOR_H
+#pragma once
 
 namespace anbox::network {
 class Connector {
  public:
 };
 }
-#endif

--- a/src/anbox/network/credentials.h
+++ b/src/anbox/network/credentials.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_CREDENTIALS_H_
-#define ANBOX_NETWORK_CREDENTIALS_H_
+#pragma once
 
 #include <sys/types.h>
 
@@ -37,4 +36,3 @@ class Credentials {
   gid_t gid_;
 };
 }
-#endif

--- a/src/anbox/network/delegate_connection_creator.h
+++ b/src/anbox/network/delegate_connection_creator.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_DELEGATE_CONNECTION_CREATOR_H_
-#define ANBOX_NETWORK_DELEGATE_CONNECTION_CREATOR_H_
+#pragma once
 
 #include <boost/asio.hpp>
 #include "anbox/network/connection_creator.h"
@@ -48,4 +47,3 @@ class DelegateConnectionCreator : public ConnectionCreator<stream_protocol> {
       delegate_;
 };
 }
-#endif

--- a/src/anbox/network/delegate_message_processor.h
+++ b/src/anbox/network/delegate_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_DELEGATE_MESSAGE_PROCESSOR_H_
-#define ANBOX_NETWORK_DELEGATE_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 
@@ -35,4 +34,3 @@ class DelegateMessageProcessor : public MessageProcessor {
   std::function<bool(const std::vector<std::uint8_t> &)> process_data_;
 };
 }
-#endif

--- a/src/anbox/network/fd_socket_transmission.h
+++ b/src/anbox/network/fd_socket_transmission.h
@@ -16,8 +16,7 @@
  * Authored by: Kevin DuBois <kevin.dubois@canonical.com>
  */
 
-#ifndef ANBOX_NETWORK_FD_SOCKET_TRANSMISSION_H_
-#define ANBOX_NETWORK_FD_SOCKET_TRANSMISSION_H_
+#pragma once
 
 #include "anbox/common/fd.h"
 
@@ -44,4 +43,3 @@ void receive_data(Fd const& socket, void* buffer, size_t bytes_requested,
                   std::vector<Fd>& fds);
 }
 
-#endif

--- a/src/anbox/network/local_socket_messenger.h
+++ b/src/anbox/network/local_socket_messenger.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_LOCAL_SOCKET_MESSENGER_H_
-#define ANBOX_NETWORK_LOCAL_SOCKET_MESSENGER_H_
+#pragma once
 
 #include "anbox/network/base_socket_messenger.h"
 #include "anbox/runtime.h"
@@ -38,4 +37,3 @@ class LocalSocketMessenger
   std::shared_ptr<boost::asio::local::stream_protocol::socket> socket_;
 };
 }
-#endif

--- a/src/anbox/network/message_processor.h
+++ b/src/anbox/network/message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_MESSAGE_PROCESSOR_H
-#define ANBOX_NETWORK_MESSAGE_PROCESSOR_H
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -28,4 +27,3 @@ class MessageProcessor {
   virtual bool process_data(const std::vector<std::uint8_t> &data) = 0;
 };
 }
-#endif

--- a/src/anbox/network/message_receiver.h
+++ b/src/anbox/network/message_receiver.h
@@ -16,8 +16,7 @@
  * Authored by: Kevin DuBois <kevin.dubois@canonical.com>
  */
 
-#ifndef ANBOX_NETWORK_MESSAGE_RECEIVER_H_
-#define ANBOX_NETWORK_MESSAGE_RECEIVER_H_
+#pragma once
 
 #include <boost/asio.hpp>
 #include <functional>
@@ -46,4 +45,3 @@ class MessageReceiver {
   MessageReceiver& operator=(MessageReceiver const&) = delete;
 };
 }
-#endif

--- a/src/anbox/network/message_sender.h
+++ b/src/anbox/network/message_sender.h
@@ -16,8 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef ANBOX_NETWORK_MESSAGE_SENDER_H_
-#define ANBOX_NETWORK_MESSAGE_SENDER_H_
+#pragma once
 
 #include <sys/types.h>
 #include <cstddef>
@@ -36,4 +35,3 @@ class MessageSender {
 };
 }
 
-#endif

--- a/src/anbox/network/published_socket_connector.h
+++ b/src/anbox/network/published_socket_connector.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PUBLISHEDSOCKETCONNECTOR_H
-#define ANBOX_PUBLISHEDSOCKETCONNECTOR_H
+#pragma once
 
 #include <boost/asio/local/stream_protocol.hpp>
 
@@ -50,4 +49,3 @@ class PublishedSocketConnector : public DoNotCopyOrMove, public Connector {
   boost::asio::local::stream_protocol::acceptor acceptor_;
 };
 }
-#endif

--- a/src/anbox/network/socket_connection.h
+++ b/src/anbox/network/socket_connection.h
@@ -16,8 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef ANBOX_NETWORK_SOCKET_CONNECTION_H_
-#define ANBOX_NETWORK_SOCKET_CONNECTION_H_
+#pragma once
 
 #include "anbox/network/connections.h"
 #include "anbox/network/message_processor.h"
@@ -60,4 +59,3 @@ class SocketConnection {
 };
 }
 
-#endif

--- a/src/anbox/network/socket_helper.h
+++ b/src/anbox/network/socket_helper.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_SOCKET_HELPER_H_
-#define ANBOX_NETWORK_SOCKET_HELPER_H_
+#pragma once
 
 #include <string>
 
@@ -25,4 +24,3 @@ bool socket_file_exists(std::string const& filename);
 bool socket_exists(std::string const& socket_name);
 std::string remove_socket_if_stale(std::string const& socket_name);
 }
-#endif

--- a/src/anbox/network/socket_messenger.h
+++ b/src/anbox/network/socket_messenger.h
@@ -16,8 +16,7 @@
  * Authored by: Kevin DuBois <kevin.dubois@canonical.com>
  */
 
-#ifndef ANBOX_NETWORK_SOCKET_MESSENGER_H_
-#define ANBOX_NETWORK_SOCKET_MESSENGER_H_
+#pragma once
 
 #include <mutex>
 
@@ -34,4 +33,3 @@ class SocketMessenger : public MessageSender, public MessageReceiver {
   virtual void close() = 0;
 };
 }
-#endif

--- a/src/anbox/network/stream_socket_transport.h
+++ b/src/anbox/network/stream_socket_transport.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_STREAM_SOCKET_TRANSPORT_H_
-#define ANBOX_STREAM_SOCKET_TRANSPORT_H_
+#pragma once
 
 #include "anbox/common/fd.h"
 #include "anbox/network/socket_messenger.h"
@@ -59,4 +58,3 @@ class StreamSocketTransport {
   SocketMessenger messenger_;
 };
 }
-#endif  // STREAM_SOCKET_TRANSPORT_H_

--- a/src/anbox/network/tcp_socket_connector.h
+++ b/src/anbox/network/tcp_socket_connector.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_TCPSOCKETCONNECTOR_H
-#define ANBOX_TCPSOCKETCONNECTOR_H
+#pragma once
 
 #include <boost/asio/ip/tcp.hpp>
 
@@ -51,4 +50,3 @@ class TcpSocketConnector : public DoNotCopyOrMove, public Connector {
   boost::asio::ip::tcp::acceptor acceptor_;
 };
 }
-#endif

--- a/src/anbox/network/tcp_socket_messenger.h
+++ b/src/anbox/network/tcp_socket_messenger.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_TCP_SOCKET_MESSENGER_H_
-#define ANBOX_NETWORK_TCP_SOCKET_MESSENGER_H_
+#pragma once
 
 #include "anbox/network/base_socket_messenger.h"
 #include "anbox/runtime.h"
@@ -38,4 +37,3 @@ class TcpSocketMessenger : public BaseSocketMessenger<boost::asio::ip::tcp> {
   unsigned short local_port_;
 };
 }
-#endif

--- a/src/anbox/not_reachable.h
+++ b/src/anbox/not_reachable.h
@@ -17,8 +17,7 @@
  *
  */
 
-#ifndef ANBOX_UTIL_NOT_REACHABLE_H_
-#define ANBOX_UTIL_NOT_REACHABLE_H_
+#pragma once
 
 #include <stdexcept>
 #include <string>
@@ -37,4 +36,3 @@ struct NotReachable : public std::logic_error {
                                 const std::string& file, std::uint32_t line);
 }
 
-#endif

--- a/src/anbox/optional.h
+++ b/src/anbox/optional.h
@@ -17,8 +17,7 @@
  *
  */
 
-#ifndef ANBOX_OPTIONAL_H_
-#define ANBOX_OPTIONAL_H_
+#pragma once
 
 #include <boost/optional.hpp>
 #include <boost/optional/optional_io.hpp>
@@ -28,4 +27,3 @@ template <typename T>
 using Optional = boost::optional<T>;
 }
 
-#endif

--- a/src/anbox/platform/base_platform.h
+++ b/src/anbox/platform/base_platform.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_POLICY_H_
-#define ANBOX_PLATFORM_POLICY_H_
+#pragma once
 
 #include "anbox/graphics/rect.h"
 #include "anbox/wm/window_state.h"
@@ -73,4 +72,3 @@ std::shared_ptr<BasePlatform> create(const std::string &name,
                                      const std::shared_ptr<input::Manager> &input_manager,
                                      const Configuration &config);
 }
-#endif

--- a/src/anbox/platform/null/platform.h
+++ b/src/anbox/platform/null/platform.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_NULL_PLATFORM_H_
-#define ANBOX_PLATFORM_NULL_PLATFORM_H_
+#pragma once
 
 #include "anbox/platform/base_platform.h"
 
@@ -40,4 +39,3 @@ class NullPlatform : public BasePlatform {
 }  // namespace wm
 }  // namespace anbox
 
-#endif

--- a/src/anbox/platform/sdl/audio_sink.h
+++ b/src/anbox/platform/sdl/audio_sink.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_SDL_AUDIO_SINK_H_
-#define ANBOX_PLATFORM_SDL_AUDIO_SINK_H_
+#pragma once
 
 #include "anbox/audio/sink.h"
 #include "anbox/graphics/buffer_queue.h"
@@ -47,4 +46,3 @@ class AudioSink : public audio::Sink {
   size_t read_buffer_left_ = 0;
 };
 }
-#endif

--- a/src/anbox/platform/sdl/keycode_converter.h
+++ b/src/anbox/platform/sdl/keycode_converter.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_SDL_KEYCODE_CONVERTER_H_
-#define ANBOX_PLATFORM_SDL_KEYCODE_CONVERTER_H_
+#pragma once
 
 #include "anbox/platform/sdl/sdl_wrapper.h"
 
@@ -33,4 +32,3 @@ class KeycodeConverter {
   static const std::array<SDL_Scancode, 249> code_map;
 };
 }
-#endif

--- a/src/anbox/platform/sdl/mir_display_connection.h
+++ b/src/anbox/platform/sdl/mir_display_connection.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_SDL_MIR_DISPLAY_CONNECTION_H_
-#define ANBOX_PLATFORM_SDL_MIR_DISPLAY_CONNECTION_H_
+#pragma once
 
 #define MIR_EGL_PLATFORM
 
@@ -46,4 +45,3 @@ class MirDisplayConnection {
   int horizontal_resolution_;
 };
 }
-#endif

--- a/src/anbox/platform/sdl/platform.h
+++ b/src/anbox/platform/sdl/platform.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_SDL_PLATFORM_H_
-#define ANBOX_PLATFORM_SDL_PLATFORM_H_
+#pragma once
 
 #include "anbox/platform/sdl/window.h"
 #include "anbox/platform/sdl/sdl_wrapper.h"
@@ -111,4 +110,3 @@ class Platform : public std::enable_shared_from_this<Platform>,
   void push_finger_motion(int x, int y, int finger_id, std::vector<input::Event> &touch_events);
 };
 }
-#endif

--- a/src/anbox/platform/sdl/sdl_wrapper.h
+++ b/src/anbox/platform/sdl/sdl_wrapper.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_SDL_WRAPPER_H_
-#define ANBOX_PLATFORM_SDL_WRAPPER_H_
+#pragma once
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-default"
@@ -25,5 +24,3 @@
 #include <SDL2/SDL_syswm.h>
 #include <SDL2/SDL_scancode.h>
 #pragma GCC diagnostic pop
-
-#endif

--- a/src/anbox/platform/sdl/window.h
+++ b/src/anbox/platform/sdl/window.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_PLATFORM_SDL_WINDOW_H_
-#define ANBOX_PLATFORM_SDL_WINDOW_H_
+#pragma once
 
 #include "anbox/wm/window.h"
 #include "anbox/platform/sdl/sdl_wrapper.h"
@@ -73,4 +72,3 @@ class Window : public std::enable_shared_from_this<Window>, public wm::Window {
   SDL_Window *window_;
 };
 }
-#endif

--- a/src/anbox/qemu/adb_message_processor.h
+++ b/src/anbox/qemu/adb_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_ADBD_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_ADBD_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 #include "anbox/network/socket_connection.h"
@@ -73,5 +72,3 @@ class AdbMessageProcessor : public network::MessageProcessor {
 };
 }  // namespace graphics
 }  // namespace anbox
-
-#endif

--- a/src/anbox/qemu/at_parser.h
+++ b/src/anbox/qemu/at_parser.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_AT_PARSER_H_
-#define ANBOX_QEMU_AT_PARSER_H_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -43,4 +42,3 @@ class AtParser {
   std::map<std::string, CommandHandler> handlers_;
 };
 }
-#endif

--- a/src/anbox/qemu/boot_properties_message_processor.h
+++ b/src/anbox/qemu/boot_properties_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_BOOT_PROPERTIES_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_BOOT_PROPERTIES_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/qemu//qemud_message_processor.h"
 
@@ -37,4 +36,3 @@ class BootPropertiesMessageProcessor : public QemudMessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/bootanimation_message_processor.h
+++ b/src/anbox/qemu/bootanimation_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_BOOT_ANIMATION_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_BOOT_ANIMATION_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/qemu//qemud_message_processor.h"
 
@@ -39,5 +38,3 @@ class BootAnimationMessageProcessor : public QemudMessageProcessor {
 };
 }  // namespace graphics
 }  // namespace anbox
-
-#endif

--- a/src/anbox/qemu/camera_message_processor.h
+++ b/src/anbox/qemu/camera_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_CAMERA_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_CAMERA_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 #include "anbox/network/socket_messenger.h"
@@ -43,4 +42,3 @@ class CameraMessageProcessor : public network::MessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/fingerprint_message_processor.h
+++ b/src/anbox/qemu/fingerprint_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_FINGERPRINT_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_FINGERPRINT_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/qemu/qemud_message_processor.h"
 
@@ -37,4 +36,3 @@ class FingerprintMessageProcessor : public QemudMessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/gps_message_processor.h
+++ b/src/anbox/qemu/gps_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_GPS_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_GPS_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/application/gps_info_broker.h"
 #include "anbox/network/message_processor.h"
@@ -36,4 +35,3 @@ class GpsMessageProcessor : public network::MessageProcessor {
   boost::signals2::connection connection_;
 };
 }
-#endif

--- a/src/anbox/qemu/gsm_message_processor.h
+++ b/src/anbox/qemu/gsm_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_GSM_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_GSM_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 #include "anbox/network/socket_messenger.h"
@@ -57,4 +56,3 @@ class GsmMessageProcessor : public network::MessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/hwcontrol_message_processor.h
+++ b/src/anbox/qemu/hwcontrol_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_HWCONTROL_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_HWCONTROL_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/qemu/qemud_message_processor.h"
 
@@ -34,4 +33,3 @@ class HwControlMessageProcessor : public QemudMessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/null_message_processor.h
+++ b/src/anbox/qemu/null_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_NULL_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_NULL_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 
@@ -32,4 +31,3 @@ class NullMessageProcessor : public network::MessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/pipe_connection_creator.h
+++ b/src/anbox/qemu/pipe_connection_creator.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_NETWORK_QEMU_PIPE_CONNECTION_CREATOR_H_
-#define ANBOX_NETWORK_QEMU_PIPE_CONNECTION_CREATOR_H_
+#pragma once
 
 #include <boost/asio.hpp>
 
@@ -75,4 +74,3 @@ class PipeConnectionCreator
   std::shared_ptr<network::Connections<network::SocketConnection>> const connections_;
 };
 }
-#endif

--- a/src/anbox/qemu/qemud_message_processor.h
+++ b/src/anbox/qemu/qemud_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_QEMUD_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_QEMUD_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 #include "anbox/network/socket_messenger.h"
@@ -47,4 +46,3 @@ class QemudMessageProcessor : public network::MessageProcessor {
 }  // namespace graphics
 }  // namespace anbox
 
-#endif

--- a/src/anbox/qemu/sensors_message_processor.h
+++ b/src/anbox/qemu/sensors_message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_SENSORS_MESSAGE_PROCESSOR_H_
-#define ANBOX_QEMU_SENSORS_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include <thread>
 
@@ -42,4 +41,3 @@ class SensorsMessageProcessor : public QemudMessageProcessor {
   std::thread thread_;
 };
 }
-#endif

--- a/src/anbox/qemu/telephony_manager.h
+++ b/src/anbox/qemu/telephony_manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_QEMU_TELEPHONY_MANAGER_H_
-#define ANBOX_QEMU_TELEPHONY_MANAGER_H_
+#pragma once
 
 #include <core/dbus/bus.h>
 #include <core/dbus/object.h>
@@ -34,4 +33,3 @@ class TelephonyManager {
   core::dbus::Object::Ptr modem_;
 };
 }
-#endif

--- a/src/anbox/rpc/channel.h
+++ b/src/anbox/rpc/channel.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_RPC_CHANNEL_H_
-#define ANBOX_RPC_CHANNEL_H_
+#pragma once
 
 #include <atomic>
 #include <memory>
@@ -63,4 +62,3 @@ class Channel {
 };
 }
 
-#endif

--- a/src/anbox/rpc/connection_creator.h
+++ b/src/anbox/rpc/connection_creator.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_RPC_CONNECTION_CREATOR_H_
-#define ANBOX_RPC_CONNECTION_CREATOR_H_
+#pragma once
 
 #include <boost/asio.hpp>
 
@@ -53,4 +52,3 @@ class ConnectionCreator
   MessageProcessorFactory message_processor_factory_;
 };
 }
-#endif

--- a/src/anbox/rpc/constants.h
+++ b/src/anbox/rpc/constants.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_RPC_CONSTANTS_H_
-#define ANBOX_RPC_CONSTANTS_H_
+#pragma once
 
 namespace anbox {
 namespace rpc {
@@ -30,4 +29,3 @@ enum MessageType {
 }  // namespace rpc
 }  // namespace network
 
-#endif

--- a/src/anbox/rpc/make_protobuf_object.h
+++ b/src/anbox/rpc/make_protobuf_object.h
@@ -16,8 +16,7 @@
  * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  */
 
-#ifndef ANBOX_RPC_MAKE_PROTOBUF_OBJECT_H_
-#define ANBOX_RPC_MAKE_PROTOBUF_OBJECT_H_
+#pragma once
 
 #include <memory>
 
@@ -34,4 +33,3 @@ auto make_protobuf_object(ProtobufType const& from) {
   return object;
 }
 }
-#endif

--- a/src/anbox/rpc/message_processor.h
+++ b/src/anbox/rpc/message_processor.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_RPC_MESSAGE_PROCESSOR_H_
-#define ANBOX_RPC_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include "anbox/network/message_processor.h"
 #include "anbox/network/message_sender.h"
@@ -65,4 +64,3 @@ class MessageProcessor : public network::MessageProcessor {
   std::shared_ptr<PendingCallCache> pending_calls_;
 };
 }
-#endif

--- a/src/anbox/rpc/pending_call_cache.h
+++ b/src/anbox/rpc/pending_call_cache.h
@@ -16,8 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef ANBOX_RPC_PENDING_CALL_CACHE_
-#define ANBOX_RPC_PENDING_CALL_CACHE_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -65,5 +64,3 @@ class PendingCallCache {
   std::map<int, PendingCall> pending_calls_;
 };
 }
-
-#endif

--- a/src/anbox/rpc/template_message_processor.h
+++ b/src/anbox/rpc/template_message_processor.h
@@ -16,8 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef ANBOX_RPC_TEMPLATE_MESSAGE_PROCESSOR_H_
-#define ANBOX_RPC_TEMPLATE_MESSAGE_PROCESSOR_H_
+#pragma once
 
 #include <google/protobuf/stubs/common.h>
 #ifdef USE_PROTOBUF_CALLBACK_HEADER
@@ -69,4 +68,3 @@ void invoke(Self* self, Bridge* rpc,
   }
 }
 }
-#endif

--- a/src/anbox/runtime.h
+++ b/src/anbox/runtime.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_RUNTIME_H_
-#define ANBOX_RUNTIME_H_
+#pragma once
 
 #include <boost/asio.hpp>
 #include <boost/version.hpp>
@@ -75,4 +74,3 @@ class Runtime : public DoNotCopyOrMove,
 
 }  // namespace anbox
 
-#endif

--- a/src/anbox/system_configuration.h
+++ b/src/anbox/system_configuration.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_SYSTEM_CONFIGURATION_H_
-#define ANBOX_SYSTEM_CONFIGURATION_H_
+#pragma once
 
 #include <string>
 #include <memory>
@@ -54,4 +53,3 @@ class SystemConfiguration {
 };
 }  // namespace anbox
 
-#endif // ANBOX_SYSTEM_CONFIGURATION_H_

--- a/src/anbox/ui/splash_screen.h
+++ b/src/anbox/ui/splash_screen.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_UI_SPLASH_SCREEN_H_
-#define ANBOX_UI_SPLASH_SCREEN_H_
+#pragma once
 
 #include <thread>
 
@@ -36,4 +35,3 @@ class SplashScreen {
   SDL_Window *window_;
 };
 }
-#endif

--- a/src/anbox/utils.h
+++ b/src/anbox/utils.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_UTILS_H_
-#define ANBOX_UTILS_H_
+#pragma once
 
 #include <boost/format.hpp>
 
@@ -79,4 +78,3 @@ inline std::string anbox::utils::string_format(const std::string &format,
   return impl::string_format(f, std::forward<Types>(args)...).str();
 }
 
-#endif

--- a/src/anbox/utils/environment_file.h
+++ b/src/anbox/utils/environment_file.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_UTILS_ENVIRONMENT_FILE_H_
-#define ANBOX_UTILS_ENVIRONMENT_FILE_H_
+#pragma once
 
 #include <map>
 #include <string>
@@ -34,4 +33,3 @@ class EnvironmentFile {
   std::map<std::string, std::string> data_;
 };
 }
-#endif

--- a/src/anbox/wm/display.h
+++ b/src/anbox/wm/display.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_DISPLAY_H_
-#define ANBOX_WM_DISPLAY_H_
+#pragma once
 
 #include <cstdint>
 
@@ -32,4 +31,3 @@ class Display {
   Display(const Display&) = delete;
 };
 }
-#endif

--- a/src/anbox/wm/manager.h
+++ b/src/anbox/wm/manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_MANAGER_H_
-#define ANBOX_WM_MANAGER_H_
+#pragma once
 
 #include "anbox/wm/window.h"
 #include "anbox/wm/window_state.h"
@@ -43,4 +42,3 @@ class Manager {
   virtual std::shared_ptr<Window> find_window_for_task(const Task::Id &task) = 0;
 };
 }
-#endif

--- a/src/anbox/wm/multi_window_manager.h
+++ b/src/anbox/wm/multi_window_manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_MULTI_WINDOW_MANAGER_H_
-#define ANBOX_WM_MULTI_WINDOW_MANAGER_H_
+#pragma once
 
 #include "anbox/wm/manager.h"
 
@@ -61,4 +60,3 @@ class MultiWindowManager : public Manager {
   std::map<Task::Id, std::shared_ptr<Window>> windows_;
 };
 }
-#endif

--- a/src/anbox/wm/single_window_manager.h
+++ b/src/anbox/wm/single_window_manager.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_SINGLE_WINDOW_MANAGER_H_
-#define ANBOX_WM_SINGLE_WINDOW_MANAGER_H_
+#pragma once
 
 #include "anbox/wm/manager.h"
 
@@ -59,4 +58,3 @@ class SingleWindowManager : public Manager {
   std::shared_ptr<Window> window_;
 };
 }
-#endif

--- a/src/anbox/wm/stack.h
+++ b/src/anbox/wm/stack.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_STACK_H_
-#define ANBOX_WM_STACK_H_
+#pragma once
 
 #include <ostream>
 
@@ -39,4 +38,3 @@ std::istream& operator>>(std::istream &in, Stack::Id &stack);
 }
 
 
-#endif

--- a/src/anbox/wm/task.h
+++ b/src/anbox/wm/task.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_TASK_H_
-#define ANBOX_WM_TASK_H_
+#pragma once
 
 #include <cstdint>
 
@@ -31,4 +30,3 @@ class Task {
   Task(const Task&) = delete;
 };
 }
-#endif

--- a/src/anbox/wm/window.h
+++ b/src/anbox/wm/window.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_WINDOW_H_
-#define ANBOX_WM_WINDOW_H_
+#pragma once
 
 #include "anbox/wm/window_state.h"
 
@@ -66,4 +65,3 @@ class Window {
   bool attached_ = false;
 };
 }
-#endif

--- a/src/anbox/wm/window_state.h
+++ b/src/anbox/wm/window_state.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef ANBOX_WM_WINDOW_STATE_H_
-#define ANBOX_WM_WINDOW_STATE_H_
+#pragma once
 
 #include "anbox/graphics/rect.h"
 #include "anbox/wm/display.h"
@@ -53,4 +52,3 @@ class WindowState {
   Stack::Id stack_;
 };
 }
-#endif


### PR DESCRIPTION
This PR replaces all occurences of:
```
#ifndef SAMPLE_H
#def SAMPLE_H

...

#endif
```
in all header files under `src/anbox` with:
```
#pragma once

...
```

Theoretically pragma once improves build times, but that could not be confirmed with my measurements.