### PR TITLE
Provide binderfs path as launch paramter

### DIFF
--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -85,6 +85,11 @@ anbox::cmds::ContainerManager::ContainerManager()
         return EXIT_FAILURE;
       }
 
+      if ((!fs::exists("/dev/binder") && !fs::exists("/dev/binderfs")) || !fs::exists("/dev/ashmem")) {
+        ERROR("Failed to start as either binder or ashmem kernel drivers are not loaded");
+        return EXIT_FAILURE;
+      }
+
       auto trap = core::posix::trap_signals_for_process(
           {core::posix::Signal::sig_term, core::posix::Signal::sig_int});
       trap->signal_raised().connect([trap](const core::posix::Signal& signal) {

--- a/src/anbox/cmds/session_manager.cpp
+++ b/src/anbox/cmds/session_manager.cpp
@@ -142,11 +142,6 @@ anbox::cmds::SessionManager::SessionManager()
       return EXIT_FAILURE;
     }
 
-    if ((!fs::exists("/dev/binder") && !fs::exists(BINDERFS_PATH)) || !fs::exists("/dev/ashmem")) {
-      ERROR("Failed to start as either binder or ashmem kernel drivers are not loaded");
-      return EXIT_FAILURE;
-    }
-
     utils::ensure_paths({
         SystemConfiguration::instance().socket_dir(),
         SystemConfiguration::instance().input_device_dir(),


### PR DESCRIPTION
This PR implements a solution to not have `BINDERFS_PATH=/dev/binderfs` hardcoded during compilation.

My plan is to provide a launch parameter for Container-Manager as `--binderfs-path`.
Currently the check whether the mount exists happens during Session-Manager startup and the first commit moves the check closer to where it is needed.

- [ ] create and use CLI parameter `--binderfs-path` for `anbox container-manager` instead of constant
- [ ] modify `snap/snapcraft.yaml` and `scripts/container-manager.sh`  to use launch parameter


### Things to consider:

**The path is either `/dev/binderfs` or `$SNAP_COMMON` when building the snap package:**
https://github.com/anbox/anbox/blob/165db5c3fccef27244a3cd8de864317a70cf3f77/CMakeLists.txt#L96-L98
https://github.com/anbox/anbox/blob/165db5c3fccef27244a3cd8de864317a70cf3f77/snap/snapcraft.yaml#L255-L263

____
**I'm not sure what this does:**
https://github.com/anbox/anbox/blob/165db5c3fccef27244a3cd8de864317a70cf3f77/src/CMakeLists.txt#L31-L33