### PR TITLE
Modularization and Separation of Responsibilities

### DIFF
--- a/.pull_request/README.md
+++ b/.pull_request/README.md
@@ -1,0 +1,14 @@
+Separation of responsibilities is a key factor to determine maintainability of software systems.
+This PR implements basic modularization into static libraries to improve code quality.
+
+During an initial analysis packages and their project internal dependencies are defined.\
+Packages in this context are names of subfolders in `src/anbox`.
+Only package `common` does not havy any other dependencies and it would make sense to start with it.
+The next packages would be `network` and `rpc`. These are still relatively easy to implement, as they are lower level packges with basic functionality. Excerpt from the dependency tree:
+```
+"common": [],
+"network": [ "common" ],
+"rpc": [ "common", "network" ],
+```
+
+During the implementation ring dependencies will have to be resolved, as for example package `wm` depends on `platform`, but `platform` also requires functionality from `wm`.

--- a/.pull_request/analysis_scripts/dependency_tree.json
+++ b/.pull_request/analysis_scripts/dependency_tree.json
@@ -1,0 +1,109 @@
+{
+    "external": [],
+    "empty": [
+        "build",
+        "external",
+        "cmds"
+    ],
+    "build": [],
+    "dbus": [
+        "application",
+        "android",
+        "sdbus-c++",
+        "wm"
+    ],
+    "platform": [
+        "graphics",
+        "wm",
+        "audio",
+        "input"
+    ],
+    "common": [],
+    "container": [
+        "common",
+        "network",
+        "rpc",
+        "android",
+        "qemu"
+    ],
+    "audio": [
+        "network",
+        "common",
+        "platform"
+    ],
+    "input": [
+        "network",
+        "qemu"
+    ],
+    "bridge": [
+        "rpc",
+        "wm",
+        "application",
+        "common",
+        "graphics",
+        "platform"
+    ],
+    "application": [
+        "android",
+        "graphics",
+        "wm"
+    ],
+    "wm": [
+        "graphics",
+        "platform",
+        "application",
+        "bridge"
+    ],
+    "graphics": [
+        "wm",
+        "network",
+        "common",
+        "external",
+        "OpenGLESDispatch",
+        "emugl"
+    ],
+    "network": [
+        "common"
+    ],
+    "testing": [
+        "common"
+    ],
+    "ui": [],
+    "android": [
+        "common"
+    ],
+    "cmds": [
+        "dbus",
+        "ui",
+        "core",
+        "application",
+        "audio",
+        "bridge",
+        "common",
+        "container",
+        "graphics",
+        "input",
+        "network",
+        "platform",
+        "qemu",
+        "rpc",
+        "wm",
+        "external",
+        "build",
+        "utils",
+        "OpenGLESDispatch",
+        "android"
+    ],
+    "rpc": [
+        "common",
+        "network"
+    ],
+    "utils": [],
+    "protobuf": [],
+    "qemu": [
+        "application",
+        "network",
+        "dbus",
+        "graphics"
+    ]
+}

--- a/.pull_request/analysis_scripts/dependency_tree.py
+++ b/.pull_request/analysis_scripts/dependency_tree.py
@@ -1,0 +1,80 @@
+
+# create a package dependency tree
+# each source files is captured with the include directives
+# then the source package and included package are connected
+# the result is a tree with three levels, but can be propagated
+#   NOTE: due to ring dependencies, the propagation is limited to
+#         four additional levels.
+#         That should give adequate insight for now.
+
+
+import os
+pwd = os.path.dirname(__file__)
+# walk up directories until git repository is found
+while not os.path.exists(f"{pwd}/.git"):
+    pwd = os.path.dirname(pwd)
+    print(pwd)
+
+src_dir = f"{pwd}/src/anbox"
+
+src_files = []
+for root, _, files in os.walk(src_dir):
+    for file in files:
+        if file.endswith(".cpp") or file.endswith(".h"):
+            src_files.append(f"{root}/{file}")
+
+# parse files into dict:
+#   file_includes = { 
+#     "src_file.h/cpp" : [ 
+#       "incl_file.h", ...
+#     ], ...
+#   }
+file_includes = {}
+for file in src_files:
+    file_includes[file] = []
+    with open(file) as fp:
+        for line in fp.readlines():
+            if line.startswith("#include \""):
+                # cut line to include content
+                # #include "anbox/daemon.h"
+                #           ^^^^^^^^^^^^^^
+                file_includes[file].append(line[10:-2])
+
+
+def top_level_dir(file_path: str) -> str:
+    if file_path.startswith("anbox/"):
+        file_path= file_path[len("anbox/"):]
+    
+    
+    if "/" not in file_path:
+        return ""
+    index_of_slash = file_path.index("/")
+    return file_path[:index_of_slash]
+
+
+# create single level dependency tree:
+#   source module: [ dest module, * ]
+dependency_tree = { "external": []}
+for fi in file_includes:
+    src_mod = top_level_dir(fi[len(src_dir) + 1:])
+    if len(src_mod) == 0:
+        src_mod = "empty" # probably root level?
+
+    if src_mod not in dependency_tree:
+        dependency_tree[src_mod] = []
+    
+    for incl in file_includes[fi]:
+        
+        dest_mod = top_level_dir(incl)
+        
+        if len(dest_mod) == 0:
+            continue
+        elif dest_mod in dependency_tree[src_mod]:
+            continue        
+        elif dest_mod == src_mod:
+            continue
+        else:
+            dependency_tree[src_mod].append(dest_mod)    
+            
+print(dependency_tree)
+


### PR DESCRIPTION
Separation of responsibilities is a key factor to determine maintainability of software systems.
This PR implements basic modularization into static libraries to improve code quality.

During an initial analysis packages and their project internal dependencies are defined.\
Packages in this context are names of subfolders in `src/anbox`.
Only package `common` does not havy any other dependencies and it would make sense to start with it.
The next packages would be `network` and `rpc`. These are still relatively easy to implement, as they are lower level packges with basic functionality. Excerpt from the dependency tree:
```
"common": [],
"network": [ "common" ],
"rpc": [ "common", "network" ],
```
____
During the implementation ring dependencies will have to be resolved, as for example package `wm` depends on `platform`, but `platform` also requires functionality from `wm`.
