### PR TITLE
Do not install cpu_features on make install

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(backward-cpp)
 
 set(BUILD_TESTING OFF)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
-add_subdirectory(cpu_features)
+add_subdirectory(cpu_features EXCLUDE_FROM_ALL)
 include(ExternalProject)
 ExternalProject_Add(sdbus-cpp
   PREFIX sdbus-cpp


### PR DESCRIPTION
We found that, when packaging anbox for Arch Linux (https://aur.archlinux.org/packages/anbox-git/), it conflicts with another package (libvolk). This is because both packages ship with cpu_features.

It is completely unnecessary to have cpu_features installed for Anbox to work, since it is a static library and is already linked into Anbox anyway.

Therefore, this pull requests disables installation of cpu_features on `make install`.