### PR TITLE
cmds: add binderfs support to system information output

### DIFF
--- a/src/anbox/cmds/system_info.cpp
+++ b/src/anbox/cmds/system_info.cpp
@@ -42,6 +42,7 @@ constexpr const char *os_release_path{"/etc/os-release"};
 constexpr const char *host_os_release_path{"/var/lib/snapd/hostfs/etc/os-release"};
 constexpr const char *proc_version_path{"/proc/version"};
 constexpr const char *binder_path{"/dev/binder"};
+constexpr const char *binderfs_path{"/dev/binderfs"};
 constexpr const char *ashmem_path{"/dev/ashmem"};
 constexpr const char *os_release_name{"NAME"};
 constexpr const char *os_release_version{"VERSION"};
@@ -83,6 +84,7 @@ class SystemInformation {
     s << "kernel:" << std::endl
       << "  version: " << kernel_info_.version << std::endl
       << "  binder: " << std::boolalpha << kernel_info_.binder << std::endl
+      << "  binderfs: " << std::boolalpha << kernel_info_.binderfs << std::endl
       << "  ashmem: " << std::boolalpha << kernel_info_.ashmem << std::endl;
 
     auto print_extensions = [](const std::vector<std::string> &extensions) {
@@ -160,6 +162,7 @@ class SystemInformation {
     }
 
     kernel_info_.binder = fs::exists(binder_path);
+    kernel_info_.binderfs = fs::exists(binderfs_path);
     kernel_info_.ashmem = fs::exists(ashmem_path);
   }
 
@@ -233,6 +236,7 @@ class SystemInformation {
   struct {
     std::string version = "n/a";
     bool binder = false;
+    bool binderfs = false;
     bool ashmem = false;
   } kernel_info_;
 


### PR DESCRIPTION
See commit for more details :
https://github.com/anbox/anbox/commit/92286b81bbcd6b51f1ebce3a4626a0ec6b21e8c4