### PR TITLE
fix the issue that the title bar disappears under multi-window strategy in some specific cases

### DIFF
--- a/src/anbox/graphics/multi_window_composer_strategy.cpp
+++ b/src/anbox/graphics/multi_window_composer_strategy.cpp
@@ -47,19 +47,21 @@ std::map<std::shared_ptr<wm::Window>, RenderableList> MultiWindowComposerStrateg
   for (auto &w : win_layers) {
     const auto &renderables = w.second;
     RenderableList final_renderables;
-    auto new_window_frame = Rect::Invalid;
-    auto max_layer_area = -1;
+
+    int32_t new_left   = INT_MAX;
+    int32_t new_top    = INT_MAX;
+    int32_t new_right  = INT_MIN;
+    int32_t new_bottom = INT_MIN;
 
     for (auto &r : renderables) {
-      const auto layer_area = r.screen_position().width() * r.screen_position().height();
       // We always prioritize layers which are lower in the list we got
       // from SurfaceFlinger as they are already ordered.
-      if (layer_area < max_layer_area)
-        continue;
-
-      max_layer_area = layer_area;
-      new_window_frame = r.screen_position();
+      if (r.screen_position().left()   < new_left)   new_left   = r.screen_position().left();
+      if (r.screen_position().top()    < new_top)    new_top    = r.screen_position().top();
+      if (r.screen_position().right()  > new_right)  new_right  = r.screen_position().right();
+      if (r.screen_position().bottom() > new_bottom) new_bottom = r.screen_position().bottom();
     }
+    auto new_window_frame = Rect{new_left, new_top, new_right, new_bottom};
 
     for (auto &r : renderables) {
       // As we get absolute display coordinates from the Android hwcomposer we


### PR DESCRIPTION
maybe fix #1184 #928

After some tests, I found that there are two situations cause the vanishment of the title bar.

One of the situation is that the `renderable` of the title bar only return the size of the title bar itself (which SHOULD be the whole size of the app). Original algorithm only find the max-sized rectangle and could not handle this situation correctly.

And another situation is a little weird. The `renderable` of the title bar just vanished without any clue, and the reason of this is beyond my knowledge.

This PR only fix the first situation. But the second situation could be easily turned to the first situation by moving the window around.

WARNING: only tested a few APKs and only tested on my laptop with kde, archlinux.

Good Luck