### PR TITLE
Missing include for std::uint32_t

### DIFF
--- a/src/anbox/input/manager.h
+++ b/src/anbox/input/manager.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <cstdint>
 
 namespace anbox{
   class Runtime;


### PR DESCRIPTION
Found while trying to build on Manjaro.