### PR TITLE
Add --launch-bounds parameter to anbox launch

### DIFF
--- a/android/service/android_api_skeleton.cpp
+++ b/android/service/android_api_skeleton.cpp
@@ -82,12 +82,10 @@ void AndroidApiSkeleton::launch_application(anbox::protobuf::bridge::LaunchAppli
 
     if (request->has_launch_bounds()) {
         argv.push_back("--launch-bounds");
-        std::stringstream launch_bounds;
-        launch_bounds << request->launch_bounds().left() << " "
-                      << request->launch_bounds().top() << " "
-                      << request->launch_bounds().right() << " "
-                      << request->launch_bounds().bottom();
-        argv.push_back(launch_bounds.str());
+        argv.push_back(std::to_string(request->launch_bounds().left()));
+        argv.push_back(std::to_string(request->launch_bounds().top()));
+        argv.push_back(std::to_string(request->launch_bounds().right()));
+        argv.push_back(std::to_string(request->launch_bounds().bottom()));
     }
 
     if (intent.has_action()) {

--- a/src/anbox/bridge/android_api_stub.cpp
+++ b/src/anbox/bridge/android_api_stub.cpp
@@ -82,10 +82,10 @@ void AndroidApiStub::launch(const android::Intent &intent,
 
   if (launch_bounds != graphics::Rect::Invalid) {
     auto rect = message.mutable_launch_bounds();
-    rect->set_left(launch_bounds_.left());
-    rect->set_top(launch_bounds_.top());
-    rect->set_right(launch_bounds_.right());
-    rect->set_bottom(launch_bounds_.bottom());
+    rect->set_left(launch_bounds.left());
+    rect->set_top(launch_bounds.top());
+    rect->set_right(launch_bounds.right());
+    rect->set_bottom(launch_bounds.bottom());
   }
 
   auto launch_intent = message.mutable_intent();

--- a/src/anbox/cmds/launch.cpp
+++ b/src/anbox/cmds/launch.cpp
@@ -148,6 +148,9 @@ anbox::cmds::Launch::Launch()
   flag(cli::make_flag(cli::Name{"use-system-dbus"},
                       cli::Description{"Use system instead of session DBus"},
                       use_system_dbus_));
+  flag(cli::make_flag(cli::Name{"launch-bounds"},
+                      cli::Description{"The launch-bounds in freeform mode. Format: 'left,top,right,bottom' without space in between"},
+                      bound_));
 
 
   action([this](const cli::Command::Context&) {
@@ -207,6 +210,6 @@ anbox::cmds::Launch::Launch()
     // going to launch the real application now.
     ss.reset();
 
-    return client.TryLaunch(intent_, stack_) ? EXIT_SUCCESS : EXIT_FAILURE;
+    return client.TryLaunch(intent_, bound_, stack_) ? EXIT_SUCCESS : EXIT_FAILURE;
   });
 }

--- a/src/anbox/cmds/launch.h
+++ b/src/anbox/cmds/launch.h
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "anbox/android/intent.h"
+#include "anbox/graphics/rect.h"
 #include "anbox/wm/stack.h"
 #include "anbox/cli.h"
 
@@ -36,6 +37,8 @@ class Launch : public cli::CommandWithFlagsAndAction {
 
   android::Intent intent_;
   wm::Stack::Id stack_ = wm::Stack::Id::Default;
+
+  anbox::graphics::Rect bound_ = anbox::graphics::Rect::Invalid;
   bool use_system_dbus_ = false;
 };
 }

--- a/src/anbox/dbus/application_manager_client.cpp
+++ b/src/anbox/dbus/application_manager_client.cpp
@@ -17,7 +17,9 @@
 
 #include "application_manager_client.h"
 
-bool ApplicationManagerClient::TryLaunch(anbox::android::Intent intent, anbox::wm::Stack::Id stack) {
+bool ApplicationManagerClient::TryLaunch(anbox::android::Intent intent,
+                                         const anbox::graphics::Rect& launch_bound,
+                                         anbox::wm::Stack::Id stack) {
   try {
     DEBUG("Sending launch intent %s to Android ..", intent);
     std::map<std::string, sdbus::Variant> intentDict;
@@ -33,6 +35,10 @@ bool ApplicationManagerClient::TryLaunch(anbox::android::Intent intent, anbox::w
       intentDict["type"] = sdbus::Variant(intent.type);
     if (intent.uri.length())
       intentDict["uri"] = sdbus::Variant(intent.uri);
+
+    if (launch_bound != anbox::graphics::Rect::Invalid) {
+        intentDict["bound"] = sdbus::Struct(std::make_tuple(launch_bound.left(), launch_bound.top(), launch_bound.right(), launch_bound.bottom()));
+    }
     this->Launch(intentDict, launch_stack.str());
   } catch (const std::exception &err) {
     ERROR("Failed to launch activity: %s", err.what());

--- a/src/anbox/dbus/application_manager_client.h
+++ b/src/anbox/dbus/application_manager_client.h
@@ -21,6 +21,7 @@
 
 #include "application_manager_client_glue.h"
 #include "anbox/android/intent.h"
+#include "anbox/graphics/rect.h"
 #include "anbox/logger.h"
 #include "anbox/wm/stack.h"
 
@@ -35,5 +36,7 @@ class ApplicationManagerClient : public sdbus::ProxyInterfaces<org::anbox::Appli
     unregisterProxy();
   }
 
-  bool TryLaunch(anbox::android::Intent intent, anbox::wm::Stack::Id stack);
+  bool TryLaunch(anbox::android::Intent intent,
+                 const anbox::graphics::Rect& launch_bound,
+                 anbox::wm::Stack::Id stack);
 };

--- a/src/anbox/dbus/application_manager_server.cpp
+++ b/src/anbox/dbus/application_manager_server.cpp
@@ -22,6 +22,9 @@
 #include "anbox/android/intent.h"
 #include "anbox/logger.h"
 
+
+typedef sdbus::Struct<std::int32_t, std::int32_t, std::int32_t, std::int32_t> DBusBounds_t;
+
 void ApplicationManagerServer::Launch(const std::map<std::string, sdbus::Variant>& intentDict, const std::string& stack) {
   anbox::android::Intent intent;
   intent.package = intentDict.count("package") ? intentDict.at("package").get<std::string>() : intent.package;
@@ -29,6 +32,13 @@ void ApplicationManagerServer::Launch(const std::map<std::string, sdbus::Variant
   intent.action = intentDict.count("action") ? intentDict.at("action").get<std::string>() : intent.action;
   intent.type = intentDict.count("type") ? intentDict.at("type").get<std::string>() : intent.type;
   intent.uri = intentDict.count("uri") ? intentDict.at("uri").get<std::string>() : intent.uri;
+
+  anbox::graphics::Rect bound = anbox::graphics::Rect::Invalid;
+  if (intentDict.count("bound")) {
+      const DBusBounds_t dbb = intentDict.at("bound").get<DBusBounds_t >();
+      bound = anbox::graphics::Rect(dbb.get<0>(), dbb.get<1>(), dbb.get<2>(), dbb.get<3>());
+      DEBUG("Received launching bound %s", bound);
+  }
   anbox::wm::Stack::Id launch_stack = anbox::wm::Stack::Id::Default;
   if (stack.length() > 0) {
     auto s = std::string(stack);
@@ -45,7 +55,7 @@ void ApplicationManagerServer::Launch(const std::map<std::string, sdbus::Variant
       throw std::runtime_error("Anbox not yet ready to launch applications");
 
     DEBUG("Launching %s", intent);
-    impl_->launch(intent, anbox::graphics::Rect::Invalid, launch_stack);
+    impl_->launch(intent, bound, launch_stack);
   } catch (std::exception& err) {
     ERROR("Failed to launch application: %s", err.what());
     throw sdbus::Error("org.anbox.InternalError", err.what());


### PR DESCRIPTION
Also fix the following at server side
1. The API stub used an Invalid rect as launching bound.
2. The Android side service emitted the launch bound as one arg while
   'am start' expect four args.