### PR TITLE
lxc: remove apparmor dependency

### DIFF
--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -390,8 +390,6 @@ void LxcContainer::start(const Configuration &configuration) {
   // anbox-support interface. The container manager itself runs within a
   // child profile snap.anbox.container-manager//lxc too.
   set_config_item("lxc.apparmor.profile", "snap.anbox.container-manager//container");
-#else
-  set_config_item(lxc_config_apparmor_profile_key, "unconfined");
 #endif
 
   if (!privileged_)


### PR DESCRIPTION
asking for "unconfined" apparmor profile causes a crash with kernels
that don't have apparmor support enabled.

> Failed to start container: Failed to start container: Failed to set config item lxc.apparmor.profile)

Closes https://github.com/anbox/anbox/issues/1852.