### PR TITLE
container-manager: fix create_directories error

### DIFF
--- a/src/anbox/cmds/container_manager.cpp
+++ b/src/anbox/cmds/container_manager.cpp
@@ -95,7 +95,7 @@ anbox::cmds::ContainerManager::ContainerManager()
       if (!data_path_.empty())
         SystemConfiguration::instance().set_data_path(data_path_);
 
-      if (!fs::exists(data_path_))
+      if (!data_path_.empty() && !fs::exists(data_path_))
         fs::create_directories(data_path_);
 
       if (!setup_mounts())


### PR DESCRIPTION
anbox container-manager crashes if `data_path_` of `anbox::cmds::ContainerManager` is not set with the error message `boost::filesystem::create_directories: Invalid argument` (#123, #1735 seem to have the same issue)
It looks like container-manager crashes on some systems if an empty path is passed to `fs::create_directories` in `src/anbox/cmds/container_manager.cpp:99`.

This PR adds an additional check to make sure the path is not empty.
