### PR TITLE
emugl:fix webview,GL_SHADING_LANGUAGE_VERSION and EGL_RENDERABLE_TYPE

### DIFF
--- a/src/anbox/graphics/emugl/RenderControl.cpp
+++ b/src/anbox/graphics/emugl/RenderControl.cpp
@@ -144,6 +144,9 @@ static EGLint rcGetGLString(EGLenum name, void* buffer, EGLint bufferSize) {
     };
 
     result = filter_extensions(result, whitelisted_extensions);
+  }else if (name == GL_SHADING_LANGUAGE_VERSION) {
+    // GL_VERSION:"OpenGL ES 2.0" matched GL_SHADING_LANGUAGE_VERSION:"OpenGL ES GLSL ES 1.00"
+    result = "OpenGL ES GLSL ES 1.00";
   }
 
   int nextBufferSize = result.size() + 1;

--- a/src/anbox/graphics/emugl/RendererConfig.cpp
+++ b/src/anbox/graphics/emugl/RendererConfig.cpp
@@ -142,6 +142,13 @@ int RendererConfigList::chooseConfig(const EGLint* attribs, EGLint* configs,
         mustReplaceSurfaceType = true;
       }
     }
+    // EGL_RENDERABLE_TYPE , fix webview
+    if (attribs[numAttribs] == EGL_RENDERABLE_TYPE) {
+      if (attribs[numAttribs + 1] > EGL_OPENGL_ES2_BIT) {
+        ERROR("EGL_RENDERABLE_TYPE can not > EGL_OPENGL_ES2_BIT");
+        return 0;
+      }
+    }
     numAttribs += 2;
   }
 


### PR DESCRIPTION
Webview will try to use Opengles3, but Anbox does not support it.

GetGLString(GL_SHADING_LANGUAGE_VERSION)，
eglChooseConfig()

see:
https://github.com/chromium/chromium/blob/67.0.3396.87/gpu/config/gpu_info_collector.cc#L160
https://github.com/chromium/chromium/blob/67.0.3396.87/ui/gl/gl_surface_egl.cc#L330
