### PR TITLE
GL_SHADING_LANGUAGE_VERSION and EGL_RENDERABLE_TYPE

### DIFF
--- a/android/opengl/system/egl/egl.cpp
+++ b/android/opengl/system/egl/egl.cpp
@@ -606,6 +606,10 @@ EGLBoolean eglGetConfigAttrib(EGLDisplay dpy, EGLConfig config, EGLint attribute
 
     if (s_display.getConfigAttrib(config, attribute, value))
     {
+        if (attribute == EGL_RENDERABLE_TYPE && *value > EGL_OPENGL_ES2_BIT){
+	    ALOGE("[%s] EGL_RENDERABLE_TYPE -> EGL_OPENGL_ES2_BIT\n", __FUNCTION__);
+            *value = EGL_OPENGL_ES2_BIT;
+        }
         return EGL_TRUE;
     }
     else

--- a/src/anbox/graphics/emugl/RenderControl.cpp
+++ b/src/anbox/graphics/emugl/RenderControl.cpp
@@ -144,6 +144,9 @@ static EGLint rcGetGLString(EGLenum name, void* buffer, EGLint bufferSize) {
     };
 
     result = filter_extensions(result, whitelisted_extensions);
+  }else if (name == GL_SHADING_LANGUAGE_VERSION) {
+    // GL_VERSION:"OpenGL ES 2.0" matched GL_SHADING_LANGUAGE_VERSION:"OpenGL ES GLSL ES 1.00"
+    result = "OpenGL ES GLSL ES 1.00";
   }
 
   int nextBufferSize = result.size() + 1;


### PR DESCRIPTION
Webview will try to use Opengles3, but Anbox does not support it.

eglGetConfigAttrib(display_, config_, EGL_RENDERABLE_TYPE,
                          &config_renderable_type);

EGL_RENDERABLE_TYPE forced return EGL_OPENGL_ES2_BIT

see:
https://github.com/chromium/chromium/blob/67.0.3396.87/gpu/config/gpu_info_collector.cc#L160
https://github.com/chromium/chromium/blob/67.0.3396.87/ui/gl/gl_surface_egl.cc#L330
https://github.com/chromium/chromium/blob/67.0.3396.87/ui/gl/gl_context_egl.cc#L80
https://github.com/chromium/chromium/blob/67.0.3396.87/ui/gl/gl_context_egl.cc#L90

