### PR TITLE
Fix build with glibc-2.34 and gcc-11

### DIFF
--- a/external/xdg/xdg.h
+++ b/external/xdg/xdg.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace xdg
 {

--- a/src/anbox/common/mount_entry.h
+++ b/src/anbox/common/mount_entry.h
@@ -19,6 +19,7 @@
 #define ANBOX_COMMON_MOUNT_ENTRY_H_
 
 #include <boost/filesystem/path.hpp>
+#include <memory>
 
 namespace anbox::common {
 class LoopDevice;

--- a/src/anbox/input/manager.h
+++ b/src/anbox/input/manager.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <cstdint>
 
 namespace anbox{
   class Runtime;


### PR DESCRIPTION
* fixes:
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.cpp:25:29: error: no declaration matches 'std::shared_ptr<anbox::common::MountEntry> anbox::common::MountEntry::create(const boost::filesystem::path&, const boost::filesystem::path&, const string&, long unsigned int, const string&)'
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.cpp:47:29: error: no declaration matches 'std::shared_ptr<anbox::common::MountEntry> anbox::common::MountEntry::create(const std::shared_ptr<anbox::common::LoopDevice>&, const boost::filesystem::path&, const string&, long unsigned int, const string&)'
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.cpp:57:29: error: no declaration matches 'std::shared_ptr<anbox::common::MountEntry> anbox::common::MountEntry::create(const boost::filesystem::path&)'
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.h:27:15: error: 'shared_ptr' in namespace 'std' does not name a template type
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.h:30:15: error: 'shared_ptr' in namespace 'std' does not name a template type
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.h:33:15: error: 'shared_ptr' in namespace 'std' does not name a template type
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/common/mount_entry.h:41:8: error: 'shared_ptr' in namespace 'std' does not name a template type

  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/external/xdg/xdg.cpp:179:44: error: no declaration matches 'std::shared_ptr<xdg::BaseDirSpecification> xdg::BaseDirSpecification::create()'
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/external/xdg/xdg.h:94:17: error: 'shared_ptr' in namespace 'std' does not name a template type
  anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/external/xdg/xdg_test.cpp:105:50: error: 'create' is not a member of 'xdg::BaseDirSpecification'
  ...

and with gcc-11:
In file included from anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/input/manager.cpp:18:
    anbox/3.0+gitAUTOINC+9de4e87cdd-r0/git/src/anbox/input/manager.h:38:8: error: 'uint32_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
       38 |   std::uint32_t next_id();
          |        ^~~~~~~~
          |        wint_t

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>