### PR TITLE
Work around bug in lxc 4.0.10

### DIFF
--- a/src/anbox/container/lxc_container.cpp
+++ b/src/anbox/container/lxc_container.cpp
@@ -336,7 +336,9 @@ void LxcContainer::start(const Configuration &configuration) {
 
   // We can mount proc/sys as rw here as we will run the container unprivileged
   // in the end
-  set_config_item("lxc.mount.auto", "proc:mixed sys:mixed cgroup:mixed");
+  set_config_item("lxc.mount.auto", "proc:mixed sys:ro cgroup:mixed");
+  // Workaround for https://github.com/lxc/lxc/issues/3964
+  set_config_item("lxc.mount.entry", "/sys/devices/virtual/net sys/devices/virtual/net none rw,bind,optional,create=dir 0 0");
 
   set_config_item("lxc.autodev", "1");
   set_config_item(lxc_config_pty_max_key, "1024");


### PR DESCRIPTION
lxc 4.0.10 evidently has [an issue](https://github.com/lxc/lxc/issues/3964) where specifying `sys.mixed` in the value of `lxc.mount.auto` causes it to fail to bind-mount `/sys/devices/virtual/net` for some reason, only leaving the unhelpful message `Operation not permitted - Failed to mount "(null)" onto "/usr/lib64/lxc/rootfs/sys/devices/virtual/net"` in `/var/lib/anbox/logs/container.log`. Specifying `sys.ro` instead of `sys.mixed` and then adding an explicit bind mount for the problematic path (i.e. replicating the behavior of `sys.mixed`) works around the problem.