### PR TITLE
add "layout" section to snapcraft.yaml to provide mapping to amdgpu.i…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,10 @@ plugs:
     bus: session
     name: org.anbox
 
+layout:
+  /usr/share/libdrm:
+    bind: $SNAP/usr/share/libdrm
+
 apps:
   anbox:
     command: bin/desktop-launch $SNAP/bin/anbox-wrapper.sh


### PR DESCRIPTION
…ds file on Ubuntu

Fixes [Issue 1031](https://github.com/anbox/anbox/issues/1031)

Tested by building snap package on Ubuntu 20.04. Anbox snap runs, installed play store, installed Minecraft, got in game, created a world and played for a few minutes. Previously only got a black window.