### PR TITLE
snapcraft: strip binaries and libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -327,3 +327,18 @@ parts:
       # in the build directory. Let's remove it so it doesn't conflict.
       rm -rf *
       snapcraftctl build
+
+
+  strip:
+    after:
+      - lxc
+      - anbox
+    plugin: nil
+    override-prime: |
+      set -x
+
+      # Strip binaries and libraries
+      strip -s "${SNAPCRAFT_PRIME}/usr/bin/anbox"
+      strip -s "${SNAPCRAFT_PRIME}/usr/bin/lxc-"*
+      strip -s "${SNAPCRAFT_PRIME}/usr/lib/liblxc.so"*
+      strip -s "${SNAPCRAFT_PRIME}/libexec/lxc/lxc-monitord"


### PR DESCRIPTION
The stripped bins/libs go from:

```
# du -smc /snap/anbox/current/usr/bin/anbox /snap/anbox/current/usr/bin/lxc-* /snap/anbox/current/usr/lib/liblxc.so.1.4.0 /snap/anbox/current/libexec/lxc/lxc-monitord
104	/snap/anbox/current/usr/bin/anbox
1	/snap/anbox/current/usr/bin/lxc-attach
1	/snap/anbox/current/usr/bin/lxc-info
1	/snap/anbox/current/usr/bin/lxc-ls
1	/snap/anbox/current/usr/bin/lxc-start
1	/snap/anbox/current/usr/bin/lxc-stop
1	/snap/anbox/current/usr/bin/lxc-top
4	/snap/anbox/current/usr/lib/liblxc.so.1.4.0
1	/snap/anbox/current/libexec/lxc/lxc-monitord
109	total
```

To:

```
# du -smc /snap/anbox/current/usr/bin/anbox /snap/anbox/current/usr/bin/lxc-* /snap/anbox/current/usr/lib/liblxc.so.1.4.0 /snap/anbox/current/libexec/lxc/lxc-monitord
4	/snap/anbox/current/usr/bin/anbox
1	/snap/anbox/current/usr/bin/lxc-attach
1	/snap/anbox/current/usr/bin/lxc-info
1	/snap/anbox/current/usr/bin/lxc-ls
1	/snap/anbox/current/usr/bin/lxc-start
1	/snap/anbox/current/usr/bin/lxc-stop
1	/snap/anbox/current/usr/bin/lxc-top
1	/snap/anbox/current/usr/lib/liblxc.so.1.4.0
1	/snap/anbox/current/libexec/lxc/lxc-monitord
5	total
```

Similar stripping is done in lxd-pkg-snap and microcloud-pkg-snap.